### PR TITLE
move bytes to bytes32, add nonce in Lock()

### DIFF
--- a/ethereum-contracts/contracts/Peggy.sol
+++ b/ethereum-contracts/contracts/Peggy.sol
@@ -8,9 +8,11 @@ contract Peggy is Valset {
     mapping (string => address) cosmosTokens;
     mapping (address => bool) cosmosTokenAddresses;
 
+    uint64 nonce = 0;
+
     /* Events  */
     event NewCosmosERC20(string name, address tokenAddress);
-    event Lock(bytes to, address token, uint64 value);
+    event Lock(bytes32 to, address token, uint64 value, uint64 nonce);
     event Unlock(address to, address token, uint64 value);
 
     /* Functions */
@@ -38,7 +40,7 @@ contract Peggy is Valset {
      * @param value       value of transference
      * @param token       token address in origin chain (0x0 if Ethereum, Cosmos for other values)
      */
-    function lock(bytes to, address tokenAddr, uint64 amount) public payable returns (bool) {
+    function lock(bytes32 to, address tokenAddr, uint64 amount) public payable returns (bool) {
         if (msg.value != 0) {
           require(tokenAddr == address(0));
           require(msg.value == amount);
@@ -47,7 +49,7 @@ contract Peggy is Valset {
         } else {
           require(ERC20(tokenAddr).transferFrom(msg.sender, this, amount));
         }
-        Lock(to, tokenAddr, amount);
+        Lock(to, tokenAddr, amount, nonce++);
         return true;
     }
 

--- a/ethereum-contracts/package.json
+++ b/ethereum-contracts/package.json
@@ -16,6 +16,7 @@
     "eth-lib": "^0.2.7",
     "ethereumjs-util": "^5.1.3",
     "keccak": "^1.4.0",
-    "keythereum": "^1.0.2"
+    "keythereum": "^1.0.2",
+    "utf8": "^3.0.0"
   }
 }

--- a/ethereum-contracts/test/peggy.js
+++ b/ethereum-contracts/test/peggy.js
@@ -100,7 +100,7 @@ contract('Peggy', function(accounts) {
       assert.equal((await standardTokenMock.balanceOf(peggy.address)).toNumber(), 1000);
       assert.strictEqual(res.logs.length, 1);
       assert.strictEqual(res.logs[0].event, "Lock");
-      assert.strictEqual(String(res.logs[0].args.to), '0xdeadbeef');
+      assert.strictEqual(String(res.logs[0].args.to).replace(/[0]+$/g, ""), '0xdeadbeef');
       assert.strictEqual(res.logs[0].args.token, standardTokenMock.address);
       assert.strictEqual(res.logs[0].args.value.toNumber(), 1000);
     });
@@ -122,7 +122,7 @@ contract('Peggy', function(accounts) {
       assert.equal((await cosmosToken.balanceOf(_account_one)).toNumber(), 500);
       assert.strictEqual(res.logs.length, 1);
       assert.strictEqual(res.logs[0].event, "Lock");
-      assert.strictEqual(String(res.logs[0].args.to), '0xdeadbeef');
+      assert.strictEqual(String(res.logs[0].args.to).replace(/[0]+$/g, ""), '0xdeadbeef');
       assert.strictEqual(res.logs[0].args.token, cosmosTokenAddress);
       assert.strictEqual(res.logs[0].args.value.toNumber(), 500);
     });
@@ -136,7 +136,7 @@ contract('Peggy', function(accounts) {
       assert.equal(ethBalance.toNumber(), 1000);
       assert.strictEqual(res.logs.length, 1);
       assert.strictEqual(res.logs[0].event, "Lock");
-      assert.strictEqual(String(res.logs[0].args.to), '0xdeadbeef');
+      assert.strictEqual(String(res.logs[0].args.to).replace(/[0]+$/g, ""), '0xdeadbeef');
       assert.strictEqual(res.logs[0].args.token, _address0);
       assert.strictEqual(res.logs[0].args.value.toNumber(), 1000);
     });

--- a/spec/readme.md
+++ b/spec/readme.md
@@ -323,7 +323,7 @@ Returns the indexes of the validators who signed on the witness.
 Locks Ethereum user's ethers/ERC20s in the contract and loggs an event. Called by the users.
 
 * `token` being `0x0` means ethereum; in this case `msg.value` must be same with `value`
-* `event Lock(bytes to, uint64 value, address token)` is logged, seen by the relayers
+* `event Lock(bytes to, uint64 value, address token, uint64 nonce)` is logged, seen by the relayers
 
 #### unlock(address[2] addressArg, uint64 value, bytes chain, uint16[] signers, uint8[] v, bytes32[] r, bytes32[] s) external returns (bool)
 


### PR DESCRIPTION
To read event logs from Witness app, events should contain only static fields. See #35. The contract, spec, and test are modified.

To distinguish events that have same fields, a nonce is added to Lock() event. Internal `nonce` variable is increased each time lock() is called.
