### PR TITLE
Add Keeper to EthBridge module and use expected keepers abstraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,3 +64,4 @@ All notable changes to this project will be documented in this file.
 - (testnet-contracts) [\#89](https://github.com/cosmos/peggy/pull/89) Dynamic validator set
 - (misc) [\#71](https://github.com/cosmos/peggy/pull/71) Dockerize validator and relayer for simple testing purposes
 - (sdk) Update SDK version to v0.37.4
+- (ethbridge) [\#100](https://github.com/cosmos/peggy/pull/100) Add Keeper to EthBridge module and move appropriate handler logic into it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,4 +64,4 @@ All notable changes to this project will be documented in this file.
 - (testnet-contracts) [\#89](https://github.com/cosmos/peggy/pull/89) Dynamic validator set
 - (misc) [\#71](https://github.com/cosmos/peggy/pull/71) Dockerize validator and relayer for simple testing purposes
 - (sdk) Update SDK version to v0.37.4
-- (ethbridge) [\#100](https://github.com/cosmos/peggy/pull/100) Add Keeper to EthBridge module and move appropriate handler logic into it
+- (ethbridge) [\#100](https://github.com/cosmos/peggy/pull/100) Add Keeper to EthBridge module and use expected keepers abstraction

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ETH Bridge Zone
+# Peggy
 
 [![version](https://img.shields.io/github/tag/cosmos/peggy.svg)](https://github.com/cosmos/peggy/releases/latest)
 [![CircleCI](https://circleci.com/gh/cosmos/peggy/tree/master.svg?style=svg)](https://circleci.com/gh/cosmos/peggy/tree/master)
@@ -8,13 +8,13 @@
 
 ## Summary
 
-Unidirectional Peggy is the starting point for cross chain value transfers from the Ethereum blockchain to Cosmos-SDK based blockchains as part of the Ethereum Cosmos Bridge project. The system accepts incoming transfers of Ethereum tokens on an Ethereum smart contract, locking them while the transaction is validated and equitable funds issued to the intended recipient on the Cosmos bridge chain.
+Peggy is the starting point for cross chain value transfers from the Ethereum blockchain to Cosmos-SDK based blockchains as part of the Ethereum Cosmos Bridge project. The system accepts incoming transfers of Ethereum tokens on an Ethereum smart contract, locking them while the transaction is validated and equitable funds issued to the intended recipient on the Cosmos bridge chain.
 
 **Note**: Requires [Go 1.13+](https://golang.org/dl/)
 
 ## Disclaimer
 
-This codebase, including all smart contract components, have not been professionally audited and are not intended for use in a production environment. As such, users should NOT trust the system to securely hold mainnet funds. Any developers attempting to use Unidirectional Peggy on the mainnet at this time will need to develop their own smart contracts or find another implementation.
+This codebase, including all smart contract components, have not been professionally audited and are not intended for use in a production environment. As such, users should NOT trust the system to securely hold mainnet funds. Any developers attempting to use Peggy on the mainnet at this time will need to develop their own smart contracts or find another implementation.
 
 ## Architecture
 

--- a/app/app.go
+++ b/app/app.go
@@ -88,6 +88,7 @@ type EthereumBridgeApp struct {
 	ParamsKeeper  params.Keeper
 
 	// EthBridge keepers
+	BridgeKeeper ethbridge.Keeper
 	OracleKeeper oracle.Keeper
 
 	// the module manager
@@ -136,6 +137,7 @@ func NewEthereumBridgeApp(
 	app.OracleKeeper = oracle.NewKeeper(app.cdc, keys[oracle.StoreKey],
 		app.StakingKeeper, oracle.DefaultCodespace, oracle.DefaultConsensusNeeded,
 	)
+	app.BridgeKeeper = ethbridge.NewKeeper(app.cdc, app.SupplyKeeper, ethbridge.DefaultCodespace)
 
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
@@ -146,7 +148,7 @@ func NewEthereumBridgeApp(
 		supply.NewAppModule(app.SupplyKeeper, app.AccountKeeper),
 		staking.NewAppModule(app.StakingKeeper, app.AccountKeeper, app.SupplyKeeper),
 		oracle.NewAppModule(app.OracleKeeper),
-		ethbridge.NewAppModule(app.OracleKeeper, app.SupplyKeeper, app.AccountKeeper, ethbridge.DefaultCodespace, app.cdc),
+		ethbridge.NewAppModule(app.OracleKeeper, app.SupplyKeeper, app.AccountKeeper, app.BridgeKeeper, ethbridge.DefaultCodespace, app.cdc),
 	)
 
 	app.mm.SetOrderEndBlockers(staking.ModuleName)

--- a/app/app.go
+++ b/app/app.go
@@ -137,7 +137,7 @@ func NewEthereumBridgeApp(
 	app.OracleKeeper = oracle.NewKeeper(app.cdc, keys[oracle.StoreKey],
 		app.StakingKeeper, oracle.DefaultCodespace, oracle.DefaultConsensusNeeded,
 	)
-	app.BridgeKeeper = ethbridge.NewKeeper(app.cdc, app.SupplyKeeper, ethbridge.DefaultCodespace)
+	app.BridgeKeeper = ethbridge.NewKeeper(app.cdc, app.SupplyKeeper, app.OracleKeeper, ethbridge.DefaultCodespace)
 
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.

--- a/x/ethbridge/alias.go
+++ b/x/ethbridge/alias.go
@@ -6,6 +6,7 @@
 package ethbridge
 
 import (
+	"github.com/cosmos/peggy/x/ethbridge/keeper"
 	"github.com/cosmos/peggy/x/ethbridge/querier"
 	"github.com/cosmos/peggy/x/ethbridge/types"
 )
@@ -24,6 +25,7 @@ const (
 
 var (
 	// functions aliases
+	NewKeeper                         = keeper.NewKeeper
 	NewQuerier                        = querier.NewQuerier
 	NewEthBridgeClaim                 = types.NewEthBridgeClaim
 	NewOracleClaimContent             = types.NewOracleClaimContent
@@ -46,6 +48,7 @@ var (
 )
 
 type (
+	Keeper                   = keeper.Keeper
 	EthBridgeClaim           = types.EthBridgeClaim
 	OracleClaimContent       = types.OracleClaimContent
 	CodeType                 = types.CodeType

--- a/x/ethbridge/handler.go
+++ b/x/ethbridge/handler.go
@@ -15,16 +15,16 @@ import (
 // NewHandler returns a handler for "ethbridge" type messages.
 func NewHandler(
 	accountKeeper auth.AccountKeeper, bridgeKeeper Keeper,
-	codespace sdk.CodespaceType, cdc *codec.Codec) sdk.Handler {
+	cdc *codec.Codec) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		ctx = ctx.WithEventManager(sdk.NewEventManager())
 		switch msg := msg.(type) {
 		case MsgCreateEthBridgeClaim:
-			return handleMsgCreateEthBridgeClaim(ctx, cdc, bridgeKeeper, msg, codespace)
+			return handleMsgCreateEthBridgeClaim(ctx, cdc, bridgeKeeper, msg)
 		case MsgBurn:
-			return handleMsgBurn(ctx, cdc, accountKeeper, bridgeKeeper, msg, codespace)
+			return handleMsgBurn(ctx, cdc, accountKeeper, bridgeKeeper, msg)
 		case MsgLock:
-			return handleMsgLock(ctx, cdc, accountKeeper, bridgeKeeper, msg, codespace)
+			return handleMsgLock(ctx, cdc, accountKeeper, bridgeKeeper, msg)
 		default:
 			errMsg := fmt.Sprintf("unrecognized ethbridge message type: %v", msg.Type())
 			return sdk.ErrUnknownRequest(errMsg).Result()
@@ -35,13 +35,9 @@ func NewHandler(
 // Handle a message to create a bridge claim
 func handleMsgCreateEthBridgeClaim(ctx sdk.Context, cdc *codec.Codec,
 	bridgeKeeper Keeper,
-	msg MsgCreateEthBridgeClaim, codespace sdk.CodespaceType) sdk.Result {
-	oracleClaim, err := types.CreateOracleClaimFromEthClaim(cdc, types.EthBridgeClaim(msg))
-	if err != nil {
-		return types.ErrJSONMarshalling(codespace).Result()
-	}
+	msg MsgCreateEthBridgeClaim) sdk.Result {
 
-	status, sdkErr := bridgeKeeper.ProcessClaim(ctx, oracleClaim)
+	status, sdkErr := bridgeKeeper.ProcessClaim(ctx, types.EthBridgeClaim(msg))
 	if sdkErr != nil {
 		return sdkErr.Result()
 	}
@@ -76,8 +72,7 @@ func handleMsgCreateEthBridgeClaim(ctx sdk.Context, cdc *codec.Codec,
 }
 
 func handleMsgBurn(ctx sdk.Context, cdc *codec.Codec,
-	accountKeeper auth.AccountKeeper, bridgeKeeper Keeper, msg MsgBurn,
-	codespace sdk.CodespaceType) sdk.Result {
+	accountKeeper auth.AccountKeeper, bridgeKeeper Keeper, msg MsgBurn) sdk.Result {
 	account := accountKeeper.GetAccount(ctx, msg.CosmosSender)
 	if account == nil {
 		return sdk.ErrInvalidAddress(msg.CosmosSender.String()).Result()
@@ -109,8 +104,7 @@ func handleMsgBurn(ctx sdk.Context, cdc *codec.Codec,
 }
 
 func handleMsgLock(ctx sdk.Context, cdc *codec.Codec,
-	accountKeeper auth.AccountKeeper, bridgeKeeper Keeper, msg MsgLock,
-	codespace sdk.CodespaceType) sdk.Result {
+	accountKeeper auth.AccountKeeper, bridgeKeeper Keeper, msg MsgLock) sdk.Result {
 	account := accountKeeper.GetAccount(ctx, msg.CosmosSender)
 	if account == nil {
 		return sdk.ErrInvalidAddress(msg.CosmosSender.String()).Result()

--- a/x/ethbridge/handler.go
+++ b/x/ethbridge/handler.go
@@ -10,12 +10,11 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/x/auth"
 )
 
 // NewHandler returns a handler for "ethbridge" type messages.
 func NewHandler(
-	accountKeeper auth.AccountKeeper, bridgeKeeper Keeper,
+	accountKeeper types.AccountKeeper, bridgeKeeper Keeper,
 	cdc *codec.Codec) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		ctx = ctx.WithEventManager(sdk.NewEventManager())
@@ -73,7 +72,7 @@ func handleMsgCreateEthBridgeClaim(ctx sdk.Context, cdc *codec.Codec,
 }
 
 func handleMsgBurn(ctx sdk.Context, cdc *codec.Codec,
-	accountKeeper auth.AccountKeeper, bridgeKeeper Keeper, msg MsgBurn) sdk.Result {
+	accountKeeper types.AccountKeeper, bridgeKeeper Keeper, msg MsgBurn) sdk.Result {
 	account := accountKeeper.GetAccount(ctx, msg.CosmosSender)
 	if account == nil {
 		return sdk.ErrInvalidAddress(msg.CosmosSender.String()).Result()
@@ -105,7 +104,7 @@ func handleMsgBurn(ctx sdk.Context, cdc *codec.Codec,
 }
 
 func handleMsgLock(ctx sdk.Context, cdc *codec.Codec,
-	accountKeeper auth.AccountKeeper, bridgeKeeper Keeper, msg MsgLock) sdk.Result {
+	accountKeeper types.AccountKeeper, bridgeKeeper Keeper, msg MsgLock) sdk.Result {
 	account := accountKeeper.GetAccount(ctx, msg.CosmosSender)
 	if account == nil {
 		return sdk.ErrInvalidAddress(msg.CosmosSender.String()).Result()

--- a/x/ethbridge/handler.go
+++ b/x/ethbridge/handler.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 package ethbridge
 
 import (

--- a/x/ethbridge/handler.go
+++ b/x/ethbridge/handler.go
@@ -14,13 +14,13 @@ import (
 
 // NewHandler returns a handler for "ethbridge" type messages.
 func NewHandler(
-	oracleKeeper oracle.Keeper, accountKeeper auth.AccountKeeper, bridgeKeeper Keeper,
+	accountKeeper auth.AccountKeeper, bridgeKeeper Keeper,
 	codespace sdk.CodespaceType, cdc *codec.Codec) sdk.Handler {
 	return func(ctx sdk.Context, msg sdk.Msg) sdk.Result {
 		ctx = ctx.WithEventManager(sdk.NewEventManager())
 		switch msg := msg.(type) {
 		case MsgCreateEthBridgeClaim:
-			return handleMsgCreateEthBridgeClaim(ctx, cdc, oracleKeeper, bridgeKeeper, msg, codespace)
+			return handleMsgCreateEthBridgeClaim(ctx, cdc, bridgeKeeper, msg, codespace)
 		case MsgBurn:
 			return handleMsgBurn(ctx, cdc, accountKeeper, bridgeKeeper, msg, codespace)
 		case MsgLock:
@@ -34,13 +34,14 @@ func NewHandler(
 
 // Handle a message to create a bridge claim
 func handleMsgCreateEthBridgeClaim(ctx sdk.Context, cdc *codec.Codec,
-	oracleKeeper oracle.Keeper, bridgeKeeper Keeper,
+	bridgeKeeper Keeper,
 	msg MsgCreateEthBridgeClaim, codespace sdk.CodespaceType) sdk.Result {
 	oracleClaim, err := types.CreateOracleClaimFromEthClaim(cdc, types.EthBridgeClaim(msg))
 	if err != nil {
 		return types.ErrJSONMarshalling(codespace).Result()
 	}
-	status, sdkErr := oracleKeeper.ProcessClaim(ctx, oracleClaim)
+
+	status, sdkErr := bridgeKeeper.ProcessClaim(ctx, oracleClaim)
 	if sdkErr != nil {
 		return sdkErr.Result()
 	}

--- a/x/ethbridge/keeper/keeper.go
+++ b/x/ethbridge/keeper/keeper.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/peggy/x/oracle"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/x/supply"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -18,13 +17,13 @@ import (
 type Keeper struct {
 	cdc *codec.Codec // The wire codec for binary encoding/decoding.
 
-	supplyKeeper supply.Keeper
-	oracleKeeper oracle.Keeper
+	supplyKeeper types.SupplyKeeper
+	oracleKeeper types.OracleKeeper
 	codespace    sdk.CodespaceType
 }
 
 // NewKeeper creates new instances of the oracle Keeper
-func NewKeeper(cdc *codec.Codec, supplyKeeper supply.Keeper, oracleKeeper oracle.Keeper, codespace sdk.CodespaceType) Keeper {
+func NewKeeper(cdc *codec.Codec, supplyKeeper types.SupplyKeeper, oracleKeeper types.OracleKeeper, codespace sdk.CodespaceType) Keeper {
 	return Keeper{
 		cdc:          cdc,
 		supplyKeeper: supplyKeeper,

--- a/x/ethbridge/keeper/keeper.go
+++ b/x/ethbridge/keeper/keeper.go
@@ -42,6 +42,7 @@ func (k Keeper) Codespace() sdk.CodespaceType {
 	return k.codespace
 }
 
+// ProcessClaim processes a new claim coming in from a validator
 func (k Keeper) ProcessClaim(ctx sdk.Context, claim types.EthBridgeClaim) (oracle.Status, sdk.Error) {
 	oracleClaim, err := types.CreateOracleClaimFromEthClaim(k.cdc, claim)
 	if err != nil {
@@ -55,6 +56,7 @@ func (k Keeper) ProcessClaim(ctx sdk.Context, claim types.EthBridgeClaim) (oracl
 	return status, nil
 }
 
+// ProcessSuccessfulClaim processes a claim that has just completed successfully with consensus
 func (k Keeper) ProcessSuccessfulClaim(ctx sdk.Context, claim string) sdk.Error {
 	oracleClaim, err := types.CreateOracleClaimFromOracleString(claim)
 	if err != nil {
@@ -76,6 +78,7 @@ func (k Keeper) ProcessSuccessfulClaim(ctx sdk.Context, claim string) sdk.Error 
 	return nil
 }
 
+// ProcessBurn processes the burn of bridged coins from the given sender
 func (k Keeper) ProcessBurn(ctx sdk.Context, cosmosSender sdk.AccAddress, amount sdk.Coins) sdk.Error {
 	err := k.supplyKeeper.SendCoinsFromAccountToModule(ctx, cosmosSender, types.ModuleName, amount)
 	if err != nil {
@@ -88,6 +91,7 @@ func (k Keeper) ProcessBurn(ctx sdk.Context, cosmosSender sdk.AccAddress, amount
 	return nil
 }
 
+// ProcessLock processes the lockup of cosmos coins from the given sender
 func (k Keeper) ProcessLock(ctx sdk.Context, cosmosSender sdk.AccAddress, amount sdk.Coins) sdk.Error {
 	err := k.supplyKeeper.SendCoinsFromAccountToModule(ctx, cosmosSender, types.ModuleName, amount)
 	if err != nil {

--- a/x/ethbridge/keeper/keeper.go
+++ b/x/ethbridge/keeper/keeper.go
@@ -6,6 +6,7 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 
 	"github.com/cosmos/peggy/x/ethbridge/types"
+	"github.com/cosmos/peggy/x/oracle"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/x/supply"
@@ -18,14 +19,16 @@ type Keeper struct {
 	cdc *codec.Codec // The wire codec for binary encoding/decoding.
 
 	supplyKeeper supply.Keeper
+	oracleKeeper oracle.Keeper
 	codespace    sdk.CodespaceType
 }
 
 // NewKeeper creates new instances of the oracle Keeper
-func NewKeeper(cdc *codec.Codec, supplyKeeper supply.Keeper, codespace sdk.CodespaceType) Keeper {
+func NewKeeper(cdc *codec.Codec, supplyKeeper supply.Keeper, oracleKeeper oracle.Keeper, codespace sdk.CodespaceType) Keeper {
 	return Keeper{
 		cdc:          cdc,
 		supplyKeeper: supplyKeeper,
+		oracleKeeper: oracleKeeper,
 		codespace:    codespace,
 	}
 }
@@ -38,6 +41,14 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 // Codespace returns the codespace
 func (k Keeper) Codespace() sdk.CodespaceType {
 	return k.codespace
+}
+
+func (k Keeper) ProcessClaim(ctx sdk.Context, claim oracle.Claim) (oracle.Status, sdk.Error) {
+	status, sdkErr := k.oracleKeeper.ProcessClaim(ctx, claim)
+	if sdkErr != nil {
+		return oracle.Status{}, sdkErr
+	}
+	return status, nil
 }
 
 func (k Keeper) ProcessSuccessfulClaim(ctx sdk.Context, claim string) sdk.Error {

--- a/x/ethbridge/keeper/keeper.go
+++ b/x/ethbridge/keeper/keeper.go
@@ -43,8 +43,13 @@ func (k Keeper) Codespace() sdk.CodespaceType {
 	return k.codespace
 }
 
-func (k Keeper) ProcessClaim(ctx sdk.Context, claim oracle.Claim) (oracle.Status, sdk.Error) {
-	status, sdkErr := k.oracleKeeper.ProcessClaim(ctx, claim)
+func (k Keeper) ProcessClaim(ctx sdk.Context, claim types.EthBridgeClaim) (oracle.Status, sdk.Error) {
+	oracleClaim, err := types.CreateOracleClaimFromEthClaim(k.cdc, claim)
+	if err != nil {
+		return oracle.Status{}, types.ErrJSONMarshalling(k.Codespace())
+	}
+
+	status, sdkErr := k.oracleKeeper.ProcessClaim(ctx, oracleClaim)
 	if sdkErr != nil {
 		return oracle.Status{}, sdkErr
 	}

--- a/x/ethbridge/keeper/keeper.go
+++ b/x/ethbridge/keeper/keeper.go
@@ -1,0 +1,62 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/tendermint/tendermint/libs/log"
+
+	"github.com/cosmos/peggy/x/ethbridge/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/x/supply"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Keeper maintains the link to data storage and exposes getter/setter methods for the various parts of the state machine
+type Keeper struct {
+	cdc *codec.Codec // The wire codec for binary encoding/decoding.
+
+	supplyKeeper supply.Keeper
+	codespace    sdk.CodespaceType
+}
+
+// NewKeeper creates new instances of the oracle Keeper
+func NewKeeper(cdc *codec.Codec, supplyKeeper supply.Keeper, codespace sdk.CodespaceType) Keeper {
+	return Keeper{
+		cdc:          cdc,
+		supplyKeeper: supplyKeeper,
+		codespace:    codespace,
+	}
+}
+
+// Logger returns a module-specific logger.
+func (k Keeper) Logger(ctx sdk.Context) log.Logger {
+	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
+}
+
+// Codespace returns the codespace
+func (k Keeper) Codespace() sdk.CodespaceType {
+	return k.codespace
+}
+
+func (k Keeper) ProcessSuccessfulClaim(ctx sdk.Context, claim string) sdk.Error {
+	oracleClaim, err := types.CreateOracleClaimFromOracleString(claim)
+	if err != nil {
+		return err
+	}
+
+	receiverAddress := oracleClaim.CosmosReceiver
+
+	if oracleClaim.ClaimType == types.LockText {
+		err = k.supplyKeeper.MintCoins(ctx, types.ModuleName, oracleClaim.Amount)
+		if err != nil {
+			return err
+		}
+	}
+	err = k.supplyKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, receiverAddress, oracleClaim.Amount)
+	if err != nil {
+		panic(err)
+	}
+	return nil
+}

--- a/x/ethbridge/keeper/keeper.go
+++ b/x/ethbridge/keeper/keeper.go
@@ -60,3 +60,23 @@ func (k Keeper) ProcessSuccessfulClaim(ctx sdk.Context, claim string) sdk.Error 
 	}
 	return nil
 }
+
+func (k Keeper) ProcessBurn(ctx sdk.Context, cosmosSender sdk.AccAddress, amount sdk.Coins) sdk.Error {
+	err := k.supplyKeeper.SendCoinsFromAccountToModule(ctx, cosmosSender, types.ModuleName, amount)
+	if err != nil {
+		return err
+	}
+	err = k.supplyKeeper.BurnCoins(ctx, types.ModuleName, amount)
+	if err != nil {
+		panic(err)
+	}
+	return nil
+}
+
+func (k Keeper) ProcessLock(ctx sdk.Context, cosmosSender sdk.AccAddress, amount sdk.Coins) sdk.Error {
+	err := k.supplyKeeper.SendCoinsFromAccountToModule(ctx, cosmosSender, types.ModuleName, amount)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/x/ethbridge/module.go
+++ b/x/ethbridge/module.go
@@ -117,7 +117,7 @@ func (AppModule) Route() string {
 
 // NewHandler returns an sdk.Handler for the ethbridge module.
 func (am AppModule) NewHandler() sdk.Handler {
-	return NewHandler(am.OracleKeeper, am.SupplyKeeper, am.AccountKeeper, am.BridgeKeeper, am.Codespace, am.Codec)
+	return NewHandler(am.OracleKeeper, am.AccountKeeper, am.BridgeKeeper, am.Codespace, am.Codec)
 }
 
 // QuerierRoute returns the ethbridge module's querier route name.

--- a/x/ethbridge/module.go
+++ b/x/ethbridge/module.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/peggy/x/ethbridge/client"
 	"github.com/cosmos/peggy/x/ethbridge/types"
-	"github.com/cosmos/peggy/x/oracle"
 	"github.com/gorilla/mux"
 	"github.com/spf13/cobra"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/cosmos/cosmos-sdk/x/auth"
 	"github.com/cosmos/cosmos-sdk/x/supply"
 )
 
@@ -75,9 +73,9 @@ type AppModule struct {
 	AppModuleBasic
 	AppModuleSimulation
 
-	OracleKeeper  oracle.Keeper
-	SupplyKeeper  supply.Keeper
-	AccountKeeper auth.AccountKeeper
+	OracleKeeper  types.OracleKeeper
+	SupplyKeeper  types.SupplyKeeper
+	AccountKeeper types.AccountKeeper
 	BridgeKeeper  Keeper
 	Codespace     sdk.CodespaceType
 	Codec         *codec.Codec
@@ -85,7 +83,7 @@ type AppModule struct {
 
 // NewAppModule creates a new AppModule object
 func NewAppModule(
-	oracleKeeper oracle.Keeper, supplyKeeper supply.Keeper, accountKeeper auth.AccountKeeper, bridgeKeeper Keeper,
+	oracleKeeper types.OracleKeeper, supplyKeeper types.SupplyKeeper, accountKeeper types.AccountKeeper, bridgeKeeper Keeper,
 	codespace sdk.CodespaceType, cdc *codec.Codec) AppModule {
 
 	return AppModule{

--- a/x/ethbridge/module.go
+++ b/x/ethbridge/module.go
@@ -117,7 +117,7 @@ func (AppModule) Route() string {
 
 // NewHandler returns an sdk.Handler for the ethbridge module.
 func (am AppModule) NewHandler() sdk.Handler {
-	return NewHandler(am.OracleKeeper, am.AccountKeeper, am.BridgeKeeper, am.Codespace, am.Codec)
+	return NewHandler(am.AccountKeeper, am.BridgeKeeper, am.Codespace, am.Codec)
 }
 
 // QuerierRoute returns the ethbridge module's querier route name.

--- a/x/ethbridge/module.go
+++ b/x/ethbridge/module.go
@@ -117,7 +117,7 @@ func (AppModule) Route() string {
 
 // NewHandler returns an sdk.Handler for the ethbridge module.
 func (am AppModule) NewHandler() sdk.Handler {
-	return NewHandler(am.AccountKeeper, am.BridgeKeeper, am.Codespace, am.Codec)
+	return NewHandler(am.AccountKeeper, am.BridgeKeeper, am.Codec)
 }
 
 // QuerierRoute returns the ethbridge module's querier route name.

--- a/x/ethbridge/module.go
+++ b/x/ethbridge/module.go
@@ -78,12 +78,15 @@ type AppModule struct {
 	OracleKeeper  oracle.Keeper
 	SupplyKeeper  supply.Keeper
 	AccountKeeper auth.AccountKeeper
+	BridgeKeeper  Keeper
 	Codespace     sdk.CodespaceType
 	Codec         *codec.Codec
 }
 
 // NewAppModule creates a new AppModule object
-func NewAppModule(oracleKeeper oracle.Keeper, supplyKeeper supply.Keeper, accountKeeper auth.AccountKeeper, codespace sdk.CodespaceType, cdc *codec.Codec) AppModule {
+func NewAppModule(
+	oracleKeeper oracle.Keeper, supplyKeeper supply.Keeper, accountKeeper auth.AccountKeeper, bridgeKeeper Keeper,
+	codespace sdk.CodespaceType, cdc *codec.Codec) AppModule {
 
 	return AppModule{
 		AppModuleBasic:      AppModuleBasic{},
@@ -92,6 +95,7 @@ func NewAppModule(oracleKeeper oracle.Keeper, supplyKeeper supply.Keeper, accoun
 		OracleKeeper:  oracleKeeper,
 		SupplyKeeper:  supplyKeeper,
 		AccountKeeper: accountKeeper,
+		BridgeKeeper:  bridgeKeeper,
 		Codespace:     codespace,
 		Codec:         cdc,
 	}
@@ -113,7 +117,7 @@ func (AppModule) Route() string {
 
 // NewHandler returns an sdk.Handler for the ethbridge module.
 func (am AppModule) NewHandler() sdk.Handler {
-	return NewHandler(am.OracleKeeper, am.SupplyKeeper, am.AccountKeeper, am.Codespace, am.Codec)
+	return NewHandler(am.OracleKeeper, am.SupplyKeeper, am.AccountKeeper, am.BridgeKeeper, am.Codespace, am.Codec)
 }
 
 // QuerierRoute returns the ethbridge module's querier route name.

--- a/x/ethbridge/querier/querier.go
+++ b/x/ethbridge/querier/querier.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 
 	"github.com/cosmos/peggy/x/ethbridge/types"
-	keep "github.com/cosmos/peggy/x/oracle/keeper"
 	oracletypes "github.com/cosmos/peggy/x/oracle/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 
@@ -18,7 +17,7 @@ const (
 )
 
 // NewQuerier is the module level router for state queries
-func NewQuerier(keeper keep.Keeper, cdc *codec.Codec, codespace sdk.CodespaceType) sdk.Querier {
+func NewQuerier(keeper types.OracleKeeper, cdc *codec.Codec, codespace sdk.CodespaceType) sdk.Querier {
 	return func(ctx sdk.Context, path []string, req abci.RequestQuery) (res []byte, err sdk.Error) {
 		switch path[0] {
 		case QueryEthProphecy:
@@ -29,7 +28,7 @@ func NewQuerier(keeper keep.Keeper, cdc *codec.Codec, codespace sdk.CodespaceTyp
 	}
 }
 
-func queryEthProphecy(ctx sdk.Context, cdc *codec.Codec, req abci.RequestQuery, keeper keep.Keeper, codespace sdk.CodespaceType) (res []byte, errSdk sdk.Error) {
+func queryEthProphecy(ctx sdk.Context, cdc *codec.Codec, req abci.RequestQuery, keeper types.OracleKeeper, codespace sdk.CodespaceType) (res []byte, errSdk sdk.Error) {
 	var params types.QueryEthProphecyParams
 
 	if err := cdc.UnmarshalJSON(req.Data, &params); err != nil {

--- a/x/ethbridge/test_common.go
+++ b/x/ethbridge/test_common.go
@@ -19,8 +19,8 @@ func CreateTestHandler(t *testing.T, consensusNeeded float64, validatorAmounts [
 	supplyKeeper.SetModuleAccount(ctx, bridgeAccount)
 
 	cdc := keeperLib.MakeTestCodec()
-	bridgeKeeper := NewKeeper(cdc, supplyKeeper, types.DefaultCodespace)
-	handler := NewHandler(oracleKeeper, accountKeeper, bridgeKeeper, types.DefaultCodespace, cdc)
+	bridgeKeeper := NewKeeper(cdc, supplyKeeper, oracleKeeper, types.DefaultCodespace)
+	handler := NewHandler(accountKeeper, bridgeKeeper, types.DefaultCodespace, cdc)
 
 	return ctx, oracleKeeper, bankKeeper, supplyKeeper, accountKeeper, validatorAddresses, handler
 }

--- a/x/ethbridge/test_common.go
+++ b/x/ethbridge/test_common.go
@@ -20,7 +20,7 @@ func CreateTestHandler(t *testing.T, consensusNeeded float64, validatorAmounts [
 
 	cdc := keeperLib.MakeTestCodec()
 	bridgeKeeper := NewKeeper(cdc, supplyKeeper, oracleKeeper, types.DefaultCodespace)
-	handler := NewHandler(accountKeeper, bridgeKeeper, types.DefaultCodespace, cdc)
+	handler := NewHandler(accountKeeper, bridgeKeeper, cdc)
 
 	return ctx, oracleKeeper, bankKeeper, supplyKeeper, accountKeeper, validatorAddresses, handler
 }

--- a/x/ethbridge/test_common.go
+++ b/x/ethbridge/test_common.go
@@ -20,7 +20,7 @@ func CreateTestHandler(t *testing.T, consensusNeeded float64, validatorAmounts [
 
 	cdc := keeperLib.MakeTestCodec()
 	bridgeKeeper := NewKeeper(cdc, supplyKeeper, types.DefaultCodespace)
-	handler := NewHandler(oracleKeeper, supplyKeeper, accountKeeper, bridgeKeeper, types.DefaultCodespace, cdc)
+	handler := NewHandler(oracleKeeper, accountKeeper, bridgeKeeper, types.DefaultCodespace, cdc)
 
 	return ctx, oracleKeeper, bankKeeper, supplyKeeper, accountKeeper, validatorAddresses, handler
 }

--- a/x/ethbridge/test_common.go
+++ b/x/ethbridge/test_common.go
@@ -19,7 +19,8 @@ func CreateTestHandler(t *testing.T, consensusNeeded float64, validatorAmounts [
 	supplyKeeper.SetModuleAccount(ctx, bridgeAccount)
 
 	cdc := keeperLib.MakeTestCodec()
-	handler := NewHandler(oracleKeeper, supplyKeeper, accountKeeper, types.DefaultCodespace, cdc)
+	bridgeKeeper := NewKeeper(cdc, supplyKeeper, types.DefaultCodespace)
+	handler := NewHandler(oracleKeeper, supplyKeeper, accountKeeper, bridgeKeeper, types.DefaultCodespace, cdc)
 
 	return ctx, oracleKeeper, bankKeeper, supplyKeeper, accountKeeper, validatorAddresses, handler
 }

--- a/x/ethbridge/types/expected_keepers.go
+++ b/x/ethbridge/types/expected_keepers.go
@@ -1,0 +1,29 @@
+package types // noalias
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authexported "github.com/cosmos/cosmos-sdk/x/auth/exported"
+	supplyexported "github.com/cosmos/cosmos-sdk/x/supply/exported"
+
+	"github.com/cosmos/peggy/x/oracle"
+)
+
+// AccountKeeper defines the expected staking keeper
+type AccountKeeper interface {
+	GetAccount(sdk.Context, sdk.AccAddress) authexported.Account
+}
+
+// SupplyKeeper defines the expected supply keeper
+type SupplyKeeper interface {
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) sdk.Error
+	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) sdk.Error
+	MintCoins(ctx sdk.Context, name string, amt sdk.Coins) sdk.Error
+	BurnCoins(ctx sdk.Context, name string, amt sdk.Coins) sdk.Error
+	SetModuleAccount(sdk.Context, supplyexported.ModuleAccountI)
+}
+
+// OracleKeeper defines the expected supply keeper
+type OracleKeeper interface {
+	ProcessClaim(ctx sdk.Context, claim oracle.Claim) (oracle.Status, sdk.Error)
+	GetProphecy(ctx sdk.Context, id string) (oracle.Prophecy, sdk.Error)
+}

--- a/x/ethbridge/types/expected_keepers.go
+++ b/x/ethbridge/types/expected_keepers.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/peggy/x/oracle"
 )
 
-// AccountKeeper defines the expected staking keeper
+// AccountKeeper defines the expected account keeper
 type AccountKeeper interface {
 	GetAccount(sdk.Context, sdk.AccAddress) authexported.Account
 }
@@ -22,7 +22,7 @@ type SupplyKeeper interface {
 	SetModuleAccount(sdk.Context, supplyexported.ModuleAccountI)
 }
 
-// OracleKeeper defines the expected supply keeper
+// OracleKeeper defines the expected oracle keeper
 type OracleKeeper interface {
 	ProcessClaim(ctx sdk.Context, claim oracle.Claim) (oracle.Status, sdk.Error)
 	GetProphecy(ctx sdk.Context, id string) (oracle.Prophecy, sdk.Error)

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/peggy/x/oracle/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
-	"github.com/cosmos/cosmos-sdk/x/staking"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -19,7 +18,7 @@ type Keeper struct {
 	cdc      *codec.Codec // The wire codec for binary encoding/decoding.
 	storeKey sdk.StoreKey // Unexposed key to access store from sdk.Context
 
-	stakeKeeper staking.Keeper
+	stakeKeeper types.StakingKeeper
 	codespace   sdk.CodespaceType
 
 	// TODO: use this as param instead
@@ -27,7 +26,7 @@ type Keeper struct {
 }
 
 // NewKeeper creates new instances of the oracle Keeper
-func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, stakeKeeper staking.Keeper, codespace sdk.CodespaceType, consensusNeeded float64) Keeper {
+func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, stakeKeeper types.StakingKeeper, codespace sdk.CodespaceType, consensusNeeded float64) Keeper {
 	if consensusNeeded <= 0 || consensusNeeded > 1 {
 		panic(types.ErrMinimumConsensusNeededInvalid(codespace).Error())
 	}

--- a/x/oracle/types/expected_keepers.go
+++ b/x/oracle/types/expected_keepers.go
@@ -1,0 +1,14 @@
+package types // noalias
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/staking"
+)
+
+// StakingKeeper defines the expected staking keeper
+type StakingKeeper interface {
+	GetValidator(ctx sdk.Context, addr sdk.ValAddress) (validator staking.Validator, found bool)
+	GetLastValidatorPower(ctx sdk.Context, operator sdk.ValAddress) (power int64)
+	GetLastTotalPower(ctx sdk.Context) (power sdk.Int)
+	GetBondedValidatorsByPower(ctx sdk.Context) []staking.Validator
+}

--- a/x/oracle/types/prophecy.go
+++ b/x/oracle/types/prophecy.go
@@ -90,7 +90,7 @@ func (prophecy Prophecy) AddClaim(validator sdk.ValAddress, claim string) {
 
 // FindHighestClaim looks through all the existing claims on a given prophecy. It adds up the total power across
 // all claims and returns the highest claim, power for that claim, and total power claimed on the prophecy overall.
-func (prophecy Prophecy) FindHighestClaim(ctx sdk.Context, stakeKeeper staking.Keeper) (string, int64, int64) {
+func (prophecy Prophecy) FindHighestClaim(ctx sdk.Context, stakeKeeper StakingKeeper) (string, int64, int64) {
 	validators := stakeKeeper.GetBondedValidatorsByPower(ctx)
 	//Index the validators by address for looking when scanning through claims
 	validatorsByAddress := make(map[string]staking.Validator)


### PR DESCRIPTION
This PR adds a new keeper to improve abstraction on the EthBridge module.
It also adds the expected keepers abstractions to both the Ethbridge and Oracle modules.

Changes/comments are based on feedback from @fedekunze in this older PR: https://github.com/cosmos/peggy/pull/79

- [x] Targeted PR against correct branch
- [x] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote tests
- [x] Updated relevant documentation (`docs/`)
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Reviewed `Files changed` in the github PR explorer

For Admin Use:

- Added appropriate labels to PR (eg. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
