### PR TITLE
Dewhitelisting modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable changes to this project will be documented in this file.
   events.
 - (ethbridge) [\#81](https://github.com/cosmos/peggy/pull/81) Add functionality for locking up cosmos coins and detecting burned coins from ethereum
 - (relayer) [\#163](https://github.com/cosmos/peggy/pull/163) Unified Relayer for chain subscription and event relay
+- (ethbridge) [\#182](https://github.com/cosmos/peggy/pull/182) Remove whitelisting and prefix Eth-tokens and change API/CLI
 
 ### Improvements
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 [![LoC](https://tokei.rs/b1/github/cosmos/peggy)](https://github.com/cosmos/peggy)
 [![API Reference](https://godoc.org/github.com/cosmos/peggy?status.svg)](https://godoc.org/github.com/cosmos/peggy)
 
+> :warning: :warning: **WARNING: This bridge is not production ready. There is at least one known security vulnerability. See: [181](https://github.com/cosmos/peggy/issues/181).**
+
+
 ## Introduction
 
 Peggy is the starting point for cross chain value transfers from the Ethereum blockchain to Cosmos-SDK based blockchains as part of the Ethereum Cosmos Bridge project. The system accepts incoming transfers of Ethereum tokens on an Ethereum smart contract, locking them while the transaction is validated and equitable funds issued to the intended recipient on the Cosmos bridge chain. The system supports value transfers from Cosmos-SDK based blockchains to the Ethereum blockchain as well through a reverse process.

--- a/cmd/ebrelayer/types/types.go
+++ b/cmd/ebrelayer/types/types.go
@@ -126,6 +126,11 @@ func NewCosmosMsg(claimType Event, cosmosSender []byte, ethereumReceiver common.
 
 // String implements fmt.Stringer
 func (c CosmosMsg) String() string {
+	if c.ClaimType == MsgLock {
+		return fmt.Sprintf("\nClaim Type: %v\nCosmos Sender: %v\nEthereum Recipient: %v"+
+			"\nSymbol: %v\nAmount: %v\n",
+			c.ClaimType.String(), string(c.CosmosSender), c.EthereumReceiver.Hex(), c.Symbol, c.Amount)
+	}
 	return fmt.Sprintf("\nClaim Type: %v\nCosmos Sender: %v\nEthereum Recipient: %v"+
 		"\nToken Address: %v\nSymbol: %v\nAmount: %v\n",
 		c.ClaimType.String(), string(c.CosmosSender), c.EthereumReceiver.Hex(),

--- a/docs/cosmos-to-ethereum.md
+++ b/docs/cosmos-to-ethereum.md
@@ -40,8 +40,8 @@ Done in 30.87s.
 Now we can send the lock transaction for 1stake token to EVM chain address `0x627306090abaB3A6e1400e9345bC60c78a8BEf57`, which is the accounts[0] address of the truffle devlop local EVM chain. We also use the newly created `BridgeToken` address from the previous step for `token-contract-address`.
 
 ```bash
-# ebcli tx ethbridge lock [cosmos-sender-address] [ethereum-receiver-address] [amount] --ethereum-chain-id [ethereum-chain-id] --token-contract-address [token-contract-address] [flags]
-ebcli tx ethbridge lock $(ebcli keys show testuser -a) 0x627306090abaB3A6e1400e9345bC60c78a8BEf57 1stake --ethereum-chain-id 3 --token-contract-address 0x409Ba3dd291bb5D48D5B4404F5EFa207441F6CbA --from testuser --yes
+# ebcli tx ethbridge lock [cosmos-sender-address] [ethereum-receiver-address] [amount] --ethereum-chain-id [ethereum-chain-id] [flags]
+ebcli tx ethbridge lock $(ebcli keys show testuser -a) 0x627306090abaB3A6e1400e9345bC60c78a8BEf57 1stake --ethereum-chain-id 3 --from testuser --yes
 ```
 
 Expected terminal output:
@@ -52,7 +52,6 @@ I[2020-03-22|18:07:01.417]
 Claim Type: lock
 Cosmos Sender: cosmos1vnt63c0wtag5jnr6e9c7jz857amxrxcel0eucl
 Ethereum Recipient: 0x627306090abaB3A6e1400e9345bC60c78a8BEf57
-Token Address: 0x409Ba3dd291bb5D48D5B4404F5EFa207441F6CbA
 Symbol: stake
 Amount: 1
 
@@ -72,7 +71,7 @@ Validator: 0xf17f52151EbEF6C7334FAD080c5704D77216b732
 
 Generating unique message for ProphecyClaim 1
 Signing message...
-Signature generated: 0xc7ccfa125f92b5ec7780ce20948c4f5a174457bc3bfe025554507003fd42dcb67be0ea6e48c9a5493d2e63ea048f40ba81abd02945ac9ae8c69cc74409b2a14000
+Signature generated: 0xae9b9ee377d85945d6516afc39c4d1f8efc1ead78ba03851d8e25cbf3227e3166a655c5cd280af9ff1a4f81ad501d754ae23b694ca834c45e0206d80504cd47b01
 Tx Status: 1 - Successful
 
 Fetching Oracle contract...

--- a/docs/setup-bridge-chain.md
+++ b/docs/setup-bridge-chain.md
@@ -71,7 +71,7 @@ ebcli tx ethbridge COMMAND --help
 # See the help for the ethbridge create claim function
 ebcli tx ethbridge create-claim --help
 # ebcli tx ethbridge create-claim [bridge-registry-contract] [nonce] [symbol] [ethereum-sender-address] [cosmos-receiver-address] [validator-address] [amount] [claim-type] --ethereum-chain-id [ethereum-chain-id] --token-contract-address [token-contract-address] [flags]
-ebcli tx ethbridge create-claim 0x30753E4A8aad7F8597332E813735Def5dD395028 0 eth 0x11111111262b236c9ac9a9a8c8e4276b5cf6b2c9 $(ebcli keys show testuser -a) $(ebcli keys show validator -a --bech val) 3eth lock --token-contract-address=0x0000000000000000000000000000000000000000 --ethereum-chain-id=3 --from=validator --yes
+ebcli tx ethbridge create-claim 0x30753E4A8aad7F8597332E813735Def5dD395028 0 eth 0x11111111262b236c9ac9a9a8c8e4276b5cf6b2c9 $(ebcli keys show testuser -a) $(ebcli keys show validator -a --bech val) 3 lock --token-contract-address=0x0000000000000000000000000000000000000000 --ethereum-chain-id=3 --from=validator --yes
 
 # You can check the transaction and message were proccessed successfully by querying the transaction hash
 # that was just generated using the following command
@@ -86,20 +86,18 @@ ebcli query account $(ebcli keys show testuser -a)
 
 # Test out burning 1 of the eth for the return trip. We'll use "0x0000000000000000000000000000000000000000" for the token-contract-address, because we're dealing with the original EVM native token (eth).
 
-# ebcli tx ethbridge burn [cosmos-sender-address] [ethereum-receiver-address] [amount] --ethereum-chain-id [ethereum-chain-id] --token-contract-address [token-contract-address] [flags]
-ebcli tx ethbridge burn $(ebcli keys show testuser -a) 0x11111111262b236c9ac9a9a8c8e4276b5cf6b2c9 1eth --ethereum-chain-id=3 --token-contract-address=0x0000000000000000000000000000000000000000 --from=testuser --yes
+# ebcli tx ethbridge burn [cosmos-sender-address] [ethereum-receiver-address] [amount] [symbol] --ethereum-chain-id [ethereum-chain-id] [flags]
+ebcli tx ethbridge burn $(ebcli keys show testuser -a) 0x11111111262b236c9ac9a9a8c8e4276b5cf6b2c9 1 peggyeth --ethereum-chain-id=3 --token-contract-address=0x0000000000000000000000000000000000000000 --from=testuser --yes
 
 # Confirm that the token was successfully burned
 ebcli query account $(ebcli keys show testuser -a)
 
-# Test out locking up a cosmos stake coin for relaying over to the EVM chain. We'll use
-# "0x345cA3e014Aaf5dcA488057592ee47305D9B3e10" for the token-contract-address because this is the addresses
-# generated for the BridgeToken when following ./setup-eth-local.md.
+# Test out locking up a cosmos stake coin for relaying over to the EVM chain.
 
 # **_NOTE_** Make sure that you transferred some stake to the testuser from the validator account like described in one of the first instructions above, otherwise testuser will have insufficient funds to complete the transaction.
 
-# ebcli tx ethbridge lock [cosmos-sender-address] [ethereum-receiver-address] [amount] --ethereum-chain-id [ethereum-chain-id] --token-contract-address [token-contract-address] [flags]
-ebcli tx ethbridge lock $(ebcli keys show testuser -a) 0x11111111262b236c9ac9a9a8c8e4276b5cf6b2c9 1stake  --ethereum-chain-id=3 --token-contract-address=0x345cA3e014Aaf5dcA488057592ee47305D9B3e10 --from=testuser --yes
+# ebcli tx ethbridge lock [cosmos-sender-address] [ethereum-receiver-address] [amount] [symbol] --ethereum-chain-id [ethereum-chain-id] [flags]
+ebcli tx ethbridge lock $(ebcli keys show testuser -a) 0x11111111262b236c9ac9a9a8c8e4276b5cf6b2c9 1 stake  --ethereum-chain-id=3 --from=testuser --yes
 
 # Confirm that the token was successfully locked
 ebcli query account $(ebcli keys show testuser -a)
@@ -107,7 +105,7 @@ ebcli query account $(ebcli keys show testuser -a)
 # Test out creating a bridge burn claim for the return trip back. This is similar to the create-claim we did earlier except for the asset being locked on the eth side, it was burned because the asset originated on the cosmos chain. Make sure you increment the nonce by one, since the first create-claim used nonce 0 this one should use nonce 1.
 
 # ebcli tx ethbridge create-claim [bridge-registry-contract] [nonce] [symbol] [ethereum-sender-address] [cosmos-receiver-address] [validator-address] [amount] [claim-type] --ethereum-chain-id [ethereum-chain-id] --token-contract-address [token-contract-address] [flags]
-ebcli tx ethbridge create-claim 0x30753E4A8aad7F8597332E813735Def5dD395028 1 stake 0x11111111262b236c9ac9a9a8c8e4276b5cf6b2c9 $(ebcli keys show testuser -a) $(ebcli keys show validator -a --bech val) 1stake burn --ethereum-chain-id=3 --token-contract-address=0x345cA3e014Aaf5dcA488057592ee47305D9B3e10 --from=validator --yes
+ebcli tx ethbridge create-claim 0x30753E4A8aad7F8597332E813735Def5dD395028 1 stake 0x11111111262b236c9ac9a9a8c8e4276b5cf6b2c9 $(ebcli keys show testuser -a) $(ebcli keys show validator -a --bech val) 1 burn --ethereum-chain-id=3 --token-contract-address=0x345cA3e014Aaf5dcA488057592ee47305D9B3e10 --from=validator --yes
 
 # Then read the prophecy to confirm it was created with the claim added
 # ebcli query ethbridge prophecy [bridge-registry-contract] [nonce] [symbol] [ethereum-sender] --ethereum-chain-id [ethereum-chain-id] --token-contract-address [token-contract-address] [flags]

--- a/x/ethbridge/client/cli/tx.go
+++ b/x/ethbridge/client/cli/tx.go
@@ -2,9 +2,12 @@ package cli
 
 import (
 	"bufio"
+	"regexp"
 	"strconv"
 
 	"github.com/cosmos/peggy/x/ethbridge/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -36,8 +39,14 @@ func GetCmdCreateEthBridgeClaim(cdc *codec.Codec) *cobra.Command {
 			}
 
 			tokenContractString := viper.GetString(types.FlagTokenContractAddr)
+			if !common.IsHexAddress(tokenContractString) {
+				return errors.Errorf("invalid [token-contract-address]: %s", tokenContractString)
+			}
 			tokenContract := types.NewEthereumAddress(tokenContractString)
 
+			if !common.IsHexAddress(args[0]) {
+				return errors.Errorf("invalid [bridge-registry-contract]: %s", args[0])
+			}
 			bridgeContract := types.NewEthereumAddress(args[0])
 
 			nonce, err := strconv.Atoi(args[1])
@@ -47,6 +56,9 @@ func GetCmdCreateEthBridgeClaim(cdc *codec.Codec) *cobra.Command {
 
 			symbol := args[2]
 			ethereumSender := types.NewEthereumAddress(args[3])
+			if !common.IsHexAddress(args[3]) {
+				return errors.Errorf("invalid [ethereum-sender-address]: %s", args[0])
+			}
 			cosmosReceiver, err := sdk.AccAddressFromBech32(args[4])
 			if err != nil {
 				return err
@@ -57,9 +69,16 @@ func GetCmdCreateEthBridgeClaim(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
+			var digitCheck = regexp.MustCompile(`^[0-9]+$`)
+			if !digitCheck.MatchString(args[6]) {
+				return types.ErrInvalidAmount
+			}
 			amount, err := strconv.ParseInt(args[6], 10, 64)
-			if err == nil {
+			if err != nil {
 				return err
+			}
+			if amount <= 0 {
+				return types.ErrInvalidAmount
 			}
 
 			claimType, err := types.StringToClaimType(args[7])
@@ -84,11 +103,11 @@ func GetCmdCreateEthBridgeClaim(cdc *codec.Codec) *cobra.Command {
 //nolint:lll
 func GetCmdBurn(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "burn [cosmos-sender-address] [ethereum-receiver-address] [amount] [symbol] --ethereum-chain-id [ethereum-chain-id] --token-contract-address [token-contract-address]",
+		Use:   "burn [cosmos-sender-address] [ethereum-receiver-address] [amount] [symbol] --ethereum-chain-id [ethereum-chain-id]",
 		Short: "burn cETH or cERC20 on the Cosmos chain",
 		Long: `This should be used to burn cETH or cERC20. It will burn your coins on the Cosmos Chain, removing them from your account and deducting them from the supply.
 		It will also trigger an event on the Cosmos Chain for relayers to watch so that they can trigger the withdrawal of the original ETH/ERC20 to you from the Ethereum contract!`,
-		Args: cobra.ExactArgs(3),
+		Args: cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -101,22 +120,31 @@ func GetCmdBurn(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			tokenContractString := viper.GetString(types.FlagTokenContractAddr)
-			tokenContract := types.NewEthereumAddress(tokenContractString)
-
 			cosmosSender, err := sdk.AccAddressFromBech32(args[0])
 			if err != nil {
 				return err
 			}
 
+			if !common.IsHexAddress(args[1]) {
+				return errors.Errorf("invalid [ethereum-receiver-address]: %s", args[1])
+			}
 			ethereumReceiver := types.NewEthereumAddress(args[1])
+
+			var digitCheck = regexp.MustCompile(`^[0-9]+$`)
+			if !digitCheck.MatchString(args[2]) {
+				return types.ErrInvalidAmount
+			}
 			amount, err := strconv.ParseInt(args[2], 10, 64)
-			if err == nil {
+			if err != nil {
 				return err
 			}
+			if amount <= 0 {
+				return types.ErrInvalidAmount
+			}
+
 			symbol := args[3]
 
-			msg := types.NewMsgBurn(ethereumChainID, tokenContract, cosmosSender, ethereumReceiver, amount, symbol)
+			msg := types.NewMsgBurn(ethereumChainID, cosmosSender, ethereumReceiver, amount, symbol)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
@@ -132,7 +160,7 @@ func GetCmdLock(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
 		Use:   "lock [cosmos-sender-address] [ethereum-receiver-address] [amount] [symbol] --ethereum-chain-id [ethereum-chain-id]",
 		Short: "This should be used to lock Cosmos-originating coins (eg: ATOM). It will lock up your coins in the supply module, removing them from your account. It will also trigger an event on the Cosmos Chain for relayers to watch so that they can trigger the minting of the pegged token on Etherum to you!",
-		Args:  cobra.ExactArgs(3),
+		Args:  cobra.ExactArgs(4),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			cliCtx := context.NewCLIContext().WithCodec(cdc)
@@ -150,11 +178,23 @@ func GetCmdLock(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
+			if !common.IsHexAddress(args[1]) {
+				return errors.Errorf("invalid [ethereum-receiver-address]: %s", args[1])
+			}
 			ethereumReceiver := types.NewEthereumAddress(args[1])
+
+			var digitCheck = regexp.MustCompile(`^[0-9]+$`)
+			if !digitCheck.MatchString(args[2]) {
+				return types.ErrInvalidAmount
+			}
 			amount, err := strconv.ParseInt(args[2], 10, 64)
-			if err == nil {
+			if err != nil {
 				return err
 			}
+			if amount <= 0 {
+				return types.ErrInvalidAmount
+			}
+
 			symbol := args[3]
 
 			msg := types.NewMsgLock(ethereumChainID, cosmosSender, ethereumReceiver, amount, symbol)

--- a/x/ethbridge/client/cli/tx.go
+++ b/x/ethbridge/client/cli/tx.go
@@ -57,8 +57,8 @@ func GetCmdCreateEthBridgeClaim(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			amount, err := sdk.ParseCoins(args[6])
-			if err != nil {
+			amount, err := strconv.ParseInt(args[6], 10, 64)
+			if err == nil {
 				return err
 			}
 
@@ -67,7 +67,8 @@ func GetCmdCreateEthBridgeClaim(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			ethBridgeClaim := types.NewEthBridgeClaim(ethereumChainID, bridgeContract, nonce, symbol, tokenContract, ethereumSender, cosmosReceiver, validator, amount, claimType)
+			ethBridgeClaim := types.NewEthBridgeClaim(ethereumChainID, bridgeContract, nonce, symbol, tokenContract,
+				ethereumSender, cosmosReceiver, validator, amount, claimType)
 
 			msg := types.NewMsgCreateEthBridgeClaim(ethBridgeClaim)
 			if err := msg.ValidateBasic(); err != nil {
@@ -83,7 +84,7 @@ func GetCmdCreateEthBridgeClaim(cdc *codec.Codec) *cobra.Command {
 //nolint:lll
 func GetCmdBurn(cdc *codec.Codec) *cobra.Command {
 	return &cobra.Command{
-		Use:   "burn [cosmos-sender-address] [ethereum-receiver-address] [amount] --ethereum-chain-id [ethereum-chain-id] --token-contract-address [token-contract-address]",
+		Use:   "burn [cosmos-sender-address] [ethereum-receiver-address] [amount] [symbol] --ethereum-chain-id [ethereum-chain-id] --token-contract-address [token-contract-address]",
 		Short: "burn cETH or cERC20 on the Cosmos chain",
 		Long: `This should be used to burn cETH or cERC20. It will burn your coins on the Cosmos Chain, removing them from your account and deducting them from the supply.
 		It will also trigger an event on the Cosmos Chain for relayers to watch so that they can trigger the withdrawal of the original ETH/ERC20 to you from the Ethereum contract!`,
@@ -109,12 +110,13 @@ func GetCmdBurn(cdc *codec.Codec) *cobra.Command {
 			}
 
 			ethereumReceiver := types.NewEthereumAddress(args[1])
-			amount, err := sdk.ParseCoins(args[2])
-			if err != nil {
+			amount, err := strconv.ParseInt(args[2], 10, 64)
+			if err == nil {
 				return err
 			}
+			symbol := args[3]
 
-			msg := types.NewMsgBurn(ethereumChainID, tokenContract, cosmosSender, ethereumReceiver, amount)
+			msg := types.NewMsgBurn(ethereumChainID, tokenContract, cosmosSender, ethereumReceiver, amount, symbol)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}
@@ -128,7 +130,7 @@ func GetCmdBurn(cdc *codec.Codec) *cobra.Command {
 func GetCmdLock(cdc *codec.Codec) *cobra.Command {
 	//nolint:lll
 	return &cobra.Command{
-		Use:   "lock [cosmos-sender-address] [ethereum-receiver-address] [amount] --ethereum-chain-id [ethereum-chain-id]",
+		Use:   "lock [cosmos-sender-address] [ethereum-receiver-address] [amount] [symbol] --ethereum-chain-id [ethereum-chain-id]",
 		Short: "This should be used to lock Cosmos-originating coins (eg: ATOM). It will lock up your coins in the supply module, removing them from your account. It will also trigger an event on the Cosmos Chain for relayers to watch so that they can trigger the minting of the pegged token on Etherum to you!",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -149,12 +151,13 @@ func GetCmdLock(cdc *codec.Codec) *cobra.Command {
 			}
 
 			ethereumReceiver := types.NewEthereumAddress(args[1])
-			amount, err := sdk.ParseCoins(args[2])
-			if err != nil {
+			amount, err := strconv.ParseInt(args[2], 10, 64)
+			if err == nil {
 				return err
 			}
+			symbol := args[3]
 
-			msg := types.NewMsgLock(ethereumChainID, cosmosSender, ethereumReceiver, amount)
+			msg := types.NewMsgLock(ethereumChainID, cosmosSender, ethereumReceiver, amount, symbol)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/ethbridge/client/cli/tx.go
+++ b/x/ethbridge/client/cli/tx.go
@@ -128,7 +128,7 @@ func GetCmdBurn(cdc *codec.Codec) *cobra.Command {
 func GetCmdLock(cdc *codec.Codec) *cobra.Command {
 	//nolint:lll
 	return &cobra.Command{
-		Use:   "lock [cosmos-sender-address] [ethereum-receiver-address] [amount] --ethereum-chain-id [ethereum-chain-id] --token-contract-address [token-contract-address]",
+		Use:   "lock [cosmos-sender-address] [ethereum-receiver-address] [amount] --ethereum-chain-id [ethereum-chain-id]",
 		Short: "This should be used to lock Cosmos-originating coins (eg: ATOM). It will lock up your coins in the supply module, removing them from your account. It will also trigger an event on the Cosmos Chain for relayers to watch so that they can trigger the minting of the pegged token on Etherum to you!",
 		Args:  cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -143,9 +143,6 @@ func GetCmdLock(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			tokenContractString := viper.GetString(types.FlagTokenContractAddr)
-			tokenContract := types.NewEthereumAddress(tokenContractString)
-
 			cosmosSender, err := sdk.AccAddressFromBech32(args[0])
 			if err != nil {
 				return err
@@ -157,7 +154,7 @@ func GetCmdLock(cdc *codec.Codec) *cobra.Command {
 				return err
 			}
 
-			msg := types.NewMsgLock(ethereumChainID, tokenContract, cosmosSender, ethereumReceiver, amount)
+			msg := types.NewMsgLock(ethereumChainID, cosmosSender, ethereumReceiver, amount)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/ethbridge/client/rest/rest.go
+++ b/x/ethbridge/client/rest/rest.go
@@ -207,7 +207,7 @@ func burnOrLockHandler(cliCtx context.CLIContext, lockOrBurn string) http.Handle
 		var msg sdk.Msg
 		switch lockOrBurn {
 		case "lock":
-			msg = types.NewMsgLock(ethereumChainID, tokenContract, cosmosSender, ethereumReceiver, amount)
+			msg = types.NewMsgLock(ethereumChainID, cosmosSender, ethereumReceiver, amount)
 		case "burn":
 			msg = types.NewMsgBurn(ethereumChainID, tokenContract, cosmosSender, ethereumReceiver, amount)
 		}

--- a/x/ethbridge/client/rest/rest.go
+++ b/x/ethbridge/client/rest/rest.go
@@ -182,8 +182,6 @@ func burnOrLockHandler(cliCtx context.CLIContext, lockOrBurn string) http.Handle
 			return
 		}
 
-		tokenContract := types.NewEthereumAddress(req.TokenContract)
-
 		cosmosSender, err := sdk.AccAddressFromBech32(req.CosmosSender)
 		if err != nil {
 			rest.WriteErrorResponse(w, http.StatusBadRequest, err.Error())
@@ -198,7 +196,7 @@ func burnOrLockHandler(cliCtx context.CLIContext, lockOrBurn string) http.Handle
 		case "lock":
 			msg = types.NewMsgLock(ethereumChainID, cosmosSender, ethereumReceiver, req.Amount, req.Symbol)
 		case "burn":
-			msg = types.NewMsgBurn(ethereumChainID, tokenContract, cosmosSender, ethereumReceiver, req.Amount, req.Symbol)
+			msg = types.NewMsgBurn(ethereumChainID, cosmosSender, ethereumReceiver, req.Amount, req.Symbol)
 		}
 		err = msg.ValidateBasic()
 		if err != nil {

--- a/x/ethbridge/handler.go
+++ b/x/ethbridge/handler.go
@@ -126,7 +126,6 @@ func handleMsgLock(
 		sdk.NewEvent(
 			types.EventTypeLock,
 			sdk.NewAttribute(types.AttributeKeyEthereumChainID, strconv.Itoa(msg.EthereumChainID)),
-			sdk.NewAttribute(types.AttributeKeyTokenContract, msg.TokenContract.String()),
 			sdk.NewAttribute(types.AttributeKeyCosmosSender, msg.CosmosSender.String()),
 			sdk.NewAttribute(types.AttributeKeyEthereumReceiver, msg.EthereumReceiver.String()),
 			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),

--- a/x/ethbridge/handler.go
+++ b/x/ethbridge/handler.go
@@ -99,7 +99,6 @@ func handleMsgBurn(
 			sdk.NewAttribute(types.AttributeKeyEthereumReceiver, msg.EthereumReceiver.String()),
 			sdk.NewAttribute(types.AttributeKeyAmount, strconv.FormatInt(msg.Amount, 10)),
 			sdk.NewAttribute(types.AttributeKeySymbol, msg.Symbol),
-			sdk.NewAttribute(types.AttributeKeyTokenContract, msg.TokenContract.String()),
 			sdk.NewAttribute(types.AttributeKeyCoins, coins.String()),
 		),
 	})

--- a/x/ethbridge/handler.go
+++ b/x/ethbridge/handler.go
@@ -95,7 +95,6 @@ func handleMsgBurn(
 		sdk.NewEvent(
 			types.EventTypeBurn,
 			sdk.NewAttribute(types.AttributeKeyEthereumChainID, strconv.Itoa(msg.EthereumChainID)),
-			sdk.NewAttribute(types.AttributeKeyTokenContract, msg.TokenContract.String()),
 			sdk.NewAttribute(types.AttributeKeyCosmosSender, msg.CosmosSender.String()),
 			sdk.NewAttribute(types.AttributeKeyEthereumReceiver, msg.EthereumReceiver.String()),
 			sdk.NewAttribute(types.AttributeKeyAmount, strconv.FormatInt(msg.Amount, 10)),

--- a/x/ethbridge/handler.go
+++ b/x/ethbridge/handler.go
@@ -42,7 +42,7 @@ func handleMsgCreateEthBridgeClaim(
 		return nil, err
 	}
 	if status.Text == oracle.SuccessStatusText {
-		if err := bridgeKeeper.ProcessSuccessfulClaim(ctx, status.FinalClaim); err != nil {
+		if err = bridgeKeeper.ProcessSuccessfulClaim(ctx, status.FinalClaim); err != nil {
 			return nil, err
 		}
 	}
@@ -57,7 +57,9 @@ func handleMsgCreateEthBridgeClaim(
 			types.EventTypeCreateClaim,
 			sdk.NewAttribute(types.AttributeKeyEthereumSender, msg.EthereumSender.String()),
 			sdk.NewAttribute(types.AttributeKeyCosmosReceiver, msg.CosmosReceiver.String()),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
+			sdk.NewAttribute(types.AttributeKeyAmount, strconv.FormatInt(msg.Amount, 10)),
+			sdk.NewAttribute(types.AttributeKeySymbol, msg.Symbol),
+			sdk.NewAttribute(types.AttributeKeyTokenContract, msg.TokenContractAddress.String()),
 			sdk.NewAttribute(types.AttributeKeyClaimType, msg.ClaimType.String()),
 		),
 		sdk.NewEvent(
@@ -79,7 +81,8 @@ func handleMsgBurn(
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.CosmosSender.String())
 	}
 
-	if err := bridgeKeeper.ProcessBurn(ctx, msg.CosmosSender, msg.Amount); err != nil {
+	coins := sdk.NewCoins(sdk.NewInt64Coin(msg.Symbol, msg.Amount))
+	if err := bridgeKeeper.ProcessBurn(ctx, msg.CosmosSender, coins); err != nil {
 		return nil, err
 	}
 
@@ -95,7 +98,10 @@ func handleMsgBurn(
 			sdk.NewAttribute(types.AttributeKeyTokenContract, msg.TokenContract.String()),
 			sdk.NewAttribute(types.AttributeKeyCosmosSender, msg.CosmosSender.String()),
 			sdk.NewAttribute(types.AttributeKeyEthereumReceiver, msg.EthereumReceiver.String()),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
+			sdk.NewAttribute(types.AttributeKeyAmount, strconv.FormatInt(msg.Amount, 10)),
+			sdk.NewAttribute(types.AttributeKeySymbol, msg.Symbol),
+			sdk.NewAttribute(types.AttributeKeyTokenContract, msg.TokenContract.String()),
+			sdk.NewAttribute(types.AttributeKeyCoins, coins.String()),
 		),
 	})
 
@@ -113,7 +119,8 @@ func handleMsgLock(
 		return nil, sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.CosmosSender.String())
 	}
 
-	if err := bridgeKeeper.ProcessLock(ctx, msg.CosmosSender, msg.Amount); err != nil {
+	coins := sdk.NewCoins(sdk.NewInt64Coin(msg.Symbol, msg.Amount))
+	if err := bridgeKeeper.ProcessLock(ctx, msg.CosmosSender, coins); err != nil {
 		return nil, err
 	}
 
@@ -128,7 +135,9 @@ func handleMsgLock(
 			sdk.NewAttribute(types.AttributeKeyEthereumChainID, strconv.Itoa(msg.EthereumChainID)),
 			sdk.NewAttribute(types.AttributeKeyCosmosSender, msg.CosmosSender.String()),
 			sdk.NewAttribute(types.AttributeKeyEthereumReceiver, msg.EthereumReceiver.String()),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.Amount.String()),
+			sdk.NewAttribute(types.AttributeKeyAmount, strconv.FormatInt(msg.Amount, 10)),
+			sdk.NewAttribute(types.AttributeKeySymbol, msg.Symbol),
+			sdk.NewAttribute(types.AttributeKeyCoins, coins.String()),
 		),
 	})
 

--- a/x/ethbridge/handler_test.go
+++ b/x/ethbridge/handler_test.go
@@ -280,8 +280,6 @@ func TestBurnEthSuccess(t *testing.T) {
 				require.Equal(t, value, ModuleName)
 			case "ethereum_chain_id":
 				eventEthereumChainID = value
-			case "token_contract_address":
-				eventTokenContract = value
 			case "cosmos_sender":
 				eventCosmosSender = value
 			case "ethereum_receiver":
@@ -298,7 +296,6 @@ func TestBurnEthSuccess(t *testing.T) {
 		}
 	}
 	require.Equal(t, eventEthereumChainID, strconv.Itoa(types.TestEthereumChainID))
-	require.Equal(t, eventTokenContract, types.TestTokenContractAddress)
 	require.Equal(t, eventCosmosSender, senderAddress.String())
 	require.Equal(t, eventEthereumReceiver, ethereumReceiver.String())
 	require.Equal(t, eventAmount, strconv.FormatInt(coinsToBurnAmount, 10))
@@ -331,8 +328,7 @@ func TestBurnEthSuccess(t *testing.T) {
 				require.Equal(t, value, ModuleName)
 			case "ethereum_chain_id":
 				eventEthereumChainID = value
-			case "token_contract_address":
-				eventTokenContract = value
+
 			case "cosmos_sender":
 				eventCosmosSender = value
 			case "ethereum_receiver":
@@ -349,7 +345,6 @@ func TestBurnEthSuccess(t *testing.T) {
 		}
 	}
 	require.Equal(t, eventEthereumChainID, strconv.Itoa(types.TestEthereumChainID))
-	require.Equal(t, eventTokenContract, types.TestTokenContractAddress)
 	require.Equal(t, eventCosmosSender, senderAddress.String())
 	require.Equal(t, eventEthereumReceiver, ethereumReceiver.String())
 	require.Equal(t, eventAmount, strconv.FormatInt(coinsToBurnAmount, 10))

--- a/x/ethbridge/handler_test.go
+++ b/x/ethbridge/handler_test.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	moduleString = "module"
-	amountString = "amount"
 	statusString = "status"
 	senderString = "sender"
 )
@@ -51,8 +50,12 @@ func TestBasicMsgs(t *testing.T) {
 				require.Equal(t, value, types.TestEthereumAddress)
 			case "cosmos_receiver":
 				require.Equal(t, value, types.TestAddress)
-			case amountString:
-				require.Equal(t, value, types.TestCoins)
+			case "amount":
+				require.Equal(t, value, strconv.FormatInt(types.TestCoinsAmount, 10))
+			case "symbol":
+				require.Equal(t, value, types.TestCoinsSymbol)
+			case "token_contract_address":
+				require.Equal(t, value, types.TestTokenContractAddress)
 			case statusString:
 				require.Equal(t, value, oracle.StatusTextToString[oracle.PendingStatusText])
 			case "claim_type":
@@ -117,8 +120,7 @@ func TestMintSuccess(t *testing.T) {
 	receiverAddress, err := sdk.AccAddressFromBech32(types.TestAddress)
 	require.NoError(t, err)
 	receiverCoins := bankKeeper.GetCoins(ctx, receiverAddress)
-	expectedCoins, err := sdk.ParseCoins(types.TestCoins)
-	require.NoError(t, err)
+	expectedCoins := sdk.Coins{sdk.NewInt64Coin(types.TestCoinsLockedSymbol, types.TestCoinsAmount)}
 	require.True(t, receiverCoins.IsEqual(expectedCoins))
 	for _, event := range res.Events {
 		for _, attribute := range event.Attributes {
@@ -136,8 +138,7 @@ func TestMintSuccess(t *testing.T) {
 	require.Nil(t, res)
 	require.True(t, strings.Contains(err.Error(), "prophecy already finalized"))
 	receiverCoins = bankKeeper.GetCoins(ctx, receiverAddress)
-	expectedCoins, err = sdk.ParseCoins(types.TestCoins)
-	require.NoError(t, err)
+	expectedCoins = sdk.Coins{sdk.NewInt64Coin(types.TestCoinsLockedSymbol, types.TestCoinsAmount)}
 	require.True(t, receiverCoins.IsEqual(expectedCoins))
 }
 
@@ -154,15 +155,15 @@ func TestNoMintFail(t *testing.T) {
 
 	ethClaim1 := types.CreateTestEthClaim(
 		t, testEthereumAddress, testTokenContractAddress,
-		valAddressVal1Pow3, testEthereumAddress, types.TestCoins, types.LockText)
+		valAddressVal1Pow3, testEthereumAddress, types.TestCoinsAmount, types.TestCoinsSymbol, types.LockText)
 	ethMsg1 := NewMsgCreateEthBridgeClaim(ethClaim1)
 	ethClaim2 := types.CreateTestEthClaim(
 		t, testEthereumAddress, testTokenContractAddress,
-		valAddressVal2Pow4, testEthereumAddress, types.TestCoins, types.LockText)
+		valAddressVal2Pow4, testEthereumAddress, types.TestCoinsAmount, types.TestCoinsSymbol, types.LockText)
 	ethMsg2 := NewMsgCreateEthBridgeClaim(ethClaim2)
 	ethClaim3 := types.CreateTestEthClaim(
 		t, testEthereumAddress, testTokenContractAddress,
-		valAddressVal3Pow3, testEthereumAddress, types.AltTestCoins, types.LockText)
+		valAddressVal3Pow3, testEthereumAddress, types.AltTestCoinsAmount, types.AltTestCoinsSymbol, types.LockText)
 	ethMsg3 := NewMsgCreateEthBridgeClaim(ethClaim3)
 
 	//Initial message
@@ -221,14 +222,16 @@ func TestBurnEthSuccess(t *testing.T) {
 	moduleAccountAddress := moduleAccount.GetAddress()
 
 	// Initial message to mint some eth
-	coinsToMint := "7ethereum"
+	coinsToMintAmount := int64(7)
+	coinsToMintSymbol := "ether"
+	coinsToMintSymbolLocked := fmt.Sprintf("%v%v", types.PeggedCoinPrefix, coinsToMintSymbol)
 
 	testTokenContractAddress := types.NewEthereumAddress(types.TestTokenContractAddress)
 	testEthereumAddress := types.NewEthereumAddress(types.TestEthereumAddress)
 
 	ethClaim1 := types.CreateTestEthClaim(
 		t, testEthereumAddress, testTokenContractAddress,
-		valAddressVal1Pow5, testEthereumAddress, coinsToMint, types.LockText)
+		valAddressVal1Pow5, testEthereumAddress, coinsToMintAmount, coinsToMintSymbol, types.LockText)
 	ethMsg1 := NewMsgCreateEthBridgeClaim(ethClaim1)
 
 	// Initial message succeeds and mints eth
@@ -238,21 +241,23 @@ func TestBurnEthSuccess(t *testing.T) {
 	receiverAddress, err := sdk.AccAddressFromBech32(types.TestAddress)
 	require.NoError(t, err)
 	receiverCoins := bankKeeper.GetCoins(ctx, receiverAddress)
-	mintedCoins, err := sdk.ParseCoins(coinsToMint)
-	require.NoError(t, err)
+	mintedCoins := sdk.Coins{sdk.NewInt64Coin(coinsToMintSymbolLocked, coinsToMintAmount)}
 	require.True(t, receiverCoins.IsEqual(mintedCoins))
 
-	coinsToBurn := "3ethereum"
+	coinsToBurnAmount := int64(3)
+	coinsToBurnSymbol := "ether"
+	coinsToBurnSymbolPrefixed := fmt.Sprintf("%v%v", types.PeggedCoinPrefix, coinsToBurnSymbol)
+
 	ethereumReceiver := types.NewEthereumAddress(types.AltTestEthereumAddress)
 
 	// Second message succeeds, burns eth and fires correct event
-	burnMsg := types.CreateTestBurnMsg(t, types.TestAddress, ethereumReceiver, coinsToBurn)
+	burnMsg := types.CreateTestBurnMsg(t, types.TestAddress, ethereumReceiver, coinsToBurnAmount,
+		coinsToBurnSymbolPrefixed)
 	res, err = handler(ctx, burnMsg)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	senderAddress := receiverAddress
-	burnedCoins, err := sdk.ParseCoins(coinsToBurn)
-	require.NoError(t, err)
+	burnedCoins := sdk.Coins{sdk.NewInt64Coin(coinsToBurnSymbolPrefixed, coinsToBurnAmount)}
 	remainingCoins := mintedCoins.Sub(burnedCoins)
 	senderCoins := bankKeeper.GetCoins(ctx, senderAddress)
 	require.True(t, senderCoins.IsEqual(remainingCoins))
@@ -261,6 +266,8 @@ func TestBurnEthSuccess(t *testing.T) {
 	eventCosmosSender := ""
 	eventEthereumReceiver := ""
 	eventAmount := ""
+	eventSymbol := ""
+	eventCoins := ""
 	for _, event := range res.Events {
 		for _, attribute := range event.Attributes {
 			value := string(attribute.Value)
@@ -279,8 +286,12 @@ func TestBurnEthSuccess(t *testing.T) {
 				eventCosmosSender = value
 			case "ethereum_receiver":
 				eventEthereumReceiver = value
-			case amountString:
+			case "amount":
 				eventAmount = value
+			case "symbol":
+				eventSymbol = value
+			case "coins":
+				eventCoins = value
 			default:
 				require.Fail(t, fmt.Sprintf("unrecognized event %s", key))
 			}
@@ -290,7 +301,9 @@ func TestBurnEthSuccess(t *testing.T) {
 	require.Equal(t, eventTokenContract, types.TestTokenContractAddress)
 	require.Equal(t, eventCosmosSender, senderAddress.String())
 	require.Equal(t, eventEthereumReceiver, ethereumReceiver.String())
-	require.Equal(t, eventAmount, coinsToBurn)
+	require.Equal(t, eventAmount, strconv.FormatInt(coinsToBurnAmount, 10))
+	require.Equal(t, eventSymbol, coinsToBurnSymbolPrefixed)
+	require.Equal(t, eventCoins, sdk.Coins{sdk.NewInt64Coin(coinsToBurnSymbolPrefixed, coinsToBurnAmount)}.String())
 
 	// Third message succeeds, burns more eth and fires correct event
 	res, err = handler(ctx, burnMsg)
@@ -304,6 +317,8 @@ func TestBurnEthSuccess(t *testing.T) {
 	eventCosmosSender = ""
 	eventEthereumReceiver = ""
 	eventAmount = ""
+	eventSymbol = ""
+	eventCoins = ""
 	for _, event := range res.Events {
 		for _, attribute := range event.Attributes {
 			value := string(attribute.Value)
@@ -322,8 +337,12 @@ func TestBurnEthSuccess(t *testing.T) {
 				eventCosmosSender = value
 			case "ethereum_receiver":
 				eventEthereumReceiver = value
-			case amountString:
+			case "amount":
 				eventAmount = value
+			case "symbol":
+				eventSymbol = value
+			case "coins":
+				eventCoins = value
 			default:
 				require.Fail(t, fmt.Sprintf("unrecognized event %s", key))
 			}
@@ -333,7 +352,9 @@ func TestBurnEthSuccess(t *testing.T) {
 	require.Equal(t, eventTokenContract, types.TestTokenContractAddress)
 	require.Equal(t, eventCosmosSender, senderAddress.String())
 	require.Equal(t, eventEthereumReceiver, ethereumReceiver.String())
-	require.Equal(t, eventAmount, coinsToBurn)
+	require.Equal(t, eventAmount, strconv.FormatInt(coinsToBurnAmount, 10))
+	require.Equal(t, eventSymbol, coinsToBurnSymbolPrefixed)
+	require.Equal(t, eventCoins, sdk.Coins{sdk.NewInt64Coin(coinsToBurnSymbolPrefixed, coinsToBurnAmount)}.String())
 
 	// Fourth message fails, not enough eth
 	res, err = handler(ctx, burnMsg)

--- a/x/ethbridge/handler_test.go
+++ b/x/ethbridge/handler_test.go
@@ -262,7 +262,6 @@ func TestBurnEthSuccess(t *testing.T) {
 	senderCoins := bankKeeper.GetCoins(ctx, senderAddress)
 	require.True(t, senderCoins.IsEqual(remainingCoins))
 	eventEthereumChainID := ""
-	eventTokenContract := ""
 	eventCosmosSender := ""
 	eventEthereumReceiver := ""
 	eventAmount := ""
@@ -310,7 +309,6 @@ func TestBurnEthSuccess(t *testing.T) {
 	senderCoins = bankKeeper.GetCoins(ctx, senderAddress)
 	require.True(t, senderCoins.IsEqual(remainingCoins))
 	eventEthereumChainID = ""
-	eventTokenContract = ""
 	eventCosmosSender = ""
 	eventEthereumReceiver = ""
 	eventAmount = ""

--- a/x/ethbridge/keeper/keeper.go
+++ b/x/ethbridge/keeper/keeper.go
@@ -58,7 +58,7 @@ func (k Keeper) ProcessSuccessfulClaim(ctx sdk.Context, claim string) error {
 	var coins sdk.Coins
 	switch oracleClaim.ClaimType {
 	case types.LockText:
-		symbol := fmt.Sprintf("peg::%v::%v", oracleClaim.TokenContractAddress, oracleClaim.Symbol)
+		symbol := fmt.Sprintf("%v%v", types.PeggedCoinPrefix, oracleClaim.Symbol)
 		coins = sdk.Coins{sdk.NewInt64Coin(symbol, oracleClaim.Amount)}
 		err = k.supplyKeeper.MintCoins(ctx, types.ModuleName, coins)
 	case types.BurnText:

--- a/x/ethbridge/keeper/keeper.go
+++ b/x/ethbridge/keeper/keeper.go
@@ -55,9 +55,15 @@ func (k Keeper) ProcessSuccessfulClaim(ctx sdk.Context, claim string) error {
 
 	receiverAddress := oracleClaim.CosmosReceiver
 
+	var coins sdk.Coins
 	switch oracleClaim.ClaimType {
-	case types.LockText, types.BurnText:
-		err = k.supplyKeeper.MintCoins(ctx, types.ModuleName, oracleClaim.Amount)
+	case types.LockText:
+		symbol := fmt.Sprintf("peg::%v::%v", oracleClaim.TokenContractAddress, oracleClaim.Symbol)
+		coins = sdk.Coins{sdk.NewInt64Coin(symbol, oracleClaim.Amount)}
+		err = k.supplyKeeper.MintCoins(ctx, types.ModuleName, coins)
+	case types.BurnText:
+		coins := sdk.Coins{sdk.NewInt64Coin(oracleClaim.Symbol, oracleClaim.Amount)}
+		err = k.supplyKeeper.MintCoins(ctx, types.ModuleName, coins)
 	default:
 		err = types.ErrInvalidClaimType
 	}
@@ -67,7 +73,7 @@ func (k Keeper) ProcessSuccessfulClaim(ctx sdk.Context, claim string) error {
 	}
 
 	if err := k.supplyKeeper.SendCoinsFromModuleToAccount(
-		ctx, types.ModuleName, receiverAddress, oracleClaim.Amount,
+		ctx, types.ModuleName, receiverAddress, coins,
 	); err != nil {
 		panic(err)
 	}

--- a/x/ethbridge/keeper/keeper.go
+++ b/x/ethbridge/keeper/keeper.go
@@ -62,7 +62,7 @@ func (k Keeper) ProcessSuccessfulClaim(ctx sdk.Context, claim string) error {
 		coins = sdk.Coins{sdk.NewInt64Coin(symbol, oracleClaim.Amount)}
 		err = k.supplyKeeper.MintCoins(ctx, types.ModuleName, coins)
 	case types.BurnText:
-		coins := sdk.Coins{sdk.NewInt64Coin(oracleClaim.Symbol, oracleClaim.Amount)}
+		coins = sdk.Coins{sdk.NewInt64Coin(oracleClaim.Symbol, oracleClaim.Amount)}
 		err = k.supplyKeeper.MintCoins(ctx, types.ModuleName, coins)
 	default:
 		err = types.ErrInvalidClaimType

--- a/x/ethbridge/keeper/querier_test.go
+++ b/x/ethbridge/keeper/querier_test.go
@@ -14,7 +14,7 @@ import (
 
 //nolint:lll
 const (
-	TestResponseJSON = "{\"id\":\"300x7B95B6EC7EbD73572298cEf32Bb54FA408207359\",\"status\":{\"text\":\"pending\",\"final_claim\":\"\"},\"claims\":[{\"ethereum_chain_id\":3,\"bridge_registry_contract_address\":\"0xC4cE93a5699c68241fc2fB503Fb0f21724A624BB\",\"nonce\":0,\"symbol\":\"eth\",\"token_contract_address\":\"0x0000000000000000000000000000000000000000\",\"ethereum_sender\":\"0x7B95B6EC7EbD73572298cEf32Bb54FA408207359\",\"cosmos_receiver\":\"cosmos1gn8409qq9hnrxde37kuxwx5hrxpfpv8426szuv\",\"validator_address\":\"cosmosvaloper1mnfm9c7cdgqnkk66sganp78m0ydmcr4pn7fqfk\",\"amount\":[{\"denom\":\"ethereum\",\"amount\":\"10\"}],\"claim_type\":\"lock\"}]}"
+	TestResponseJSON = "{\"id\":\"300x7B95B6EC7EbD73572298cEf32Bb54FA408207359\",\"status\":{\"text\":\"pending\",\"final_claim\":\"\"},\"claims\":[{\"ethereum_chain_id\":3,\"bridge_registry_contract_address\":\"0xC4cE93a5699c68241fc2fB503Fb0f21724A624BB\",\"nonce\":0,\"symbol\":\"eth\",\"token_contract_address\":\"0x0000000000000000000000000000000000000000\",\"ethereum_sender\":\"0x7B95B6EC7EbD73572298cEf32Bb54FA408207359\",\"cosmos_receiver\":\"cosmos1gn8409qq9hnrxde37kuxwx5hrxpfpv8426szuv\",\"validator_address\":\"cosmosvaloper1mnfm9c7cdgqnkk66sganp78m0ydmcr4pn7fqfk\",\"amount\":10,\"claim_type\":\"lock\"}]}"
 )
 
 func TestNewQuerier(t *testing.T) {
@@ -45,7 +45,7 @@ func TestQueryEthProphecy(t *testing.T) {
 
 	initialEthBridgeClaim := types.CreateTestEthClaim(
 		t, testBridgeContractAddress, testTokenContractAddress, valAddress,
-		testEthereumAddress, types.TestCoins, types.LockText)
+		testEthereumAddress, types.TestCoinsAmount, types.TestCoinsSymbol, types.LockText)
 	oracleClaim, _ := types.CreateOracleClaimFromEthClaim(cdc, initialEthBridgeClaim)
 	_, err := oracleKeeper.ProcessClaim(ctx, oracleClaim)
 	require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestQueryEthProphecy(t *testing.T) {
 
 	bz, err2 := cdc.MarshalJSON(types.NewQueryEthProphecyParams(
 		types.TestEthereumChainID, testBridgeContractAddress, types.TestNonce,
-		types.TestSymbol, testTokenContractAddress, testEthereumAddress))
+		types.TestCoinsSymbol, testTokenContractAddress, testEthereumAddress))
 	require.Nil(t, err2)
 
 	query := abci.RequestQuery{
@@ -85,7 +85,7 @@ func TestQueryEthProphecy(t *testing.T) {
 
 	bz2, err6 := cdc.MarshalJSON(types.NewQueryEthProphecyParams(
 		types.TestEthereumChainID, testBridgeContractAddress, 12,
-		types.TestSymbol, testTokenContractAddress, badEthereumAddress))
+		types.TestCoinsSymbol, testTokenContractAddress, badEthereumAddress))
 	require.Nil(t, err6)
 
 	query2 := abci.RequestQuery{
@@ -102,7 +102,7 @@ func TestQueryEthProphecy(t *testing.T) {
 	bz3, err8 := cdc.MarshalJSON(
 		types.NewQueryEthProphecyParams(
 			types.TestEthereumChainID, testBridgeContractAddress, 12,
-			types.TestSymbol, testTokenContractAddress, emptyEthereumAddress))
+			types.TestCoinsSymbol, testTokenContractAddress, emptyEthereumAddress))
 
 	require.Nil(t, err8)
 

--- a/x/ethbridge/types/errors.go
+++ b/x/ethbridge/types/errors.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"fmt"
+
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
 
@@ -13,7 +15,8 @@ var (
 		"invalid symbol provided, symbol 'eth' must have null address set as token contract address")
 	ErrInvalidClaimType       = sdkerrors.Register(ModuleName, 5, "invalid claim type provided")
 	ErrInvalidEthereumChainID = sdkerrors.Register(ModuleName, 6, "invalid ethereum chain id")
-	ErrInvalidAmount          = sdkerrors.Register(ModuleName, 7, "amount must be > 0")
+	ErrInvalidAmount          = sdkerrors.Register(ModuleName, 7, "amount must be a valid integer > 0")
 	ErrInvalidSymbol          = sdkerrors.Register(ModuleName, 8, "symbol must be 1 character or more")
-	ErrInvalidBurnSymbol      = sdkerrors.Register(ModuleName, 9, "symbol of token to burn must be in the form peg::ethereumTokenContractAddress::ethereumSymbol")
+	ErrInvalidBurnSymbol      = sdkerrors.Register(ModuleName, 9,
+		fmt.Sprintf("symbol of token to burn must be in the form %v{ethereumSymbol}", PeggedCoinPrefix))
 )

--- a/x/ethbridge/types/errors.go
+++ b/x/ethbridge/types/errors.go
@@ -15,5 +15,5 @@ var (
 	ErrInvalidEthereumChainID = sdkerrors.Register(ModuleName, 6, "invalid ethereum chain id")
 	ErrInvalidAmount          = sdkerrors.Register(ModuleName, 7, "amount must be > 0")
 	ErrInvalidSymbol          = sdkerrors.Register(ModuleName, 8, "symbol must be 1 character or more")
-	ErrInvalidBurnSymbol      = sdkerrors.Register(ModuleName, 8, "symbol of token to burn must be in the form peg::ethereumTokenContractAddress::ethereumSymbol")
+	ErrInvalidBurnSymbol      = sdkerrors.Register(ModuleName, 9, "symbol of token to burn must be in the form peg::ethereumTokenContractAddress::ethereumSymbol")
 )

--- a/x/ethbridge/types/errors.go
+++ b/x/ethbridge/types/errors.go
@@ -13,4 +13,7 @@ var (
 		"invalid symbol provided, symbol 'eth' must have null address set as token contract address")
 	ErrInvalidClaimType       = sdkerrors.Register(ModuleName, 5, "invalid claim type provided")
 	ErrInvalidEthereumChainID = sdkerrors.Register(ModuleName, 6, "invalid ethereum chain id")
+	ErrInvalidAmount          = sdkerrors.Register(ModuleName, 7, "amount must be > 0")
+	ErrInvalidSymbol          = sdkerrors.Register(ModuleName, 8, "symbol must be 1 character or more")
+	ErrInvalidBurnSymbol      = sdkerrors.Register(ModuleName, 8, "symbol of token to burn must be in the form peg::ethereumTokenContractAddress::ethereumSymbol")
 )

--- a/x/ethbridge/types/ethereum.go
+++ b/x/ethbridge/types/ethereum.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
+const PeggedCoinPrefix = "peggy"
+
 // EthereumAddress defines a standard ethereum address
 type EthereumAddress gethCommon.Address
 

--- a/x/ethbridge/types/events.go
+++ b/x/ethbridge/types/events.go
@@ -10,6 +10,8 @@ var (
 	AttributeKeyEthereumSender = "ethereum_sender"
 	AttributeKeyCosmosReceiver = "cosmos_receiver"
 	AttributeKeyAmount         = "amount"
+	AttributeKeySymbol         = "symbol"
+	AttributeKeyCoins          = "coins"
 	AttributeKeyStatus         = "status"
 	AttributeKeyClaimType      = "claim_type"
 

--- a/x/ethbridge/types/msgs.go
+++ b/x/ethbridge/types/msgs.go
@@ -17,17 +17,15 @@ type MsgLock struct {
 	CosmosSender     sdk.AccAddress  `json:"cosmos_sender" yaml:"cosmos_sender"`
 	Amount           sdk.Coins       `json:"amount" yaml:"amount"`
 	EthereumChainID  int             `json:"ethereum_chain_id" yaml:"ethereum_chain_id"`
-	TokenContract    EthereumAddress `json:"token_contract_address" yaml:"token_contract_address"`
 	EthereumReceiver EthereumAddress `json:"ethereum_receiver" yaml:"ethereum_receiver"`
 }
 
 // NewMsgLock is a constructor function for MsgLock
 func NewMsgLock(
-	ethereumChainID int, tokenContract EthereumAddress, cosmosSender sdk.AccAddress,
+	ethereumChainID int, cosmosSender sdk.AccAddress,
 	ethereumReceiver EthereumAddress, amount sdk.Coins) MsgLock {
 	return MsgLock{
 		EthereumChainID:  ethereumChainID,
-		TokenContract:    tokenContract,
 		CosmosSender:     cosmosSender,
 		EthereumReceiver: ethereumReceiver,
 		Amount:           amount,
@@ -44,14 +42,6 @@ func (msg MsgLock) Type() string { return "lock" }
 func (msg MsgLock) ValidateBasic() error {
 	if strconv.Itoa(msg.EthereumChainID) == "" {
 		return sdkerrors.Wrapf(ErrInvalidEthereumChainID, "%d", msg.EthereumChainID)
-	}
-
-	if msg.TokenContract.String() == "" {
-		return ErrInvalidEthAddress
-	}
-
-	if !gethCommon.IsHexAddress(msg.TokenContract.String()) {
-		return ErrInvalidEthAddress
 	}
 
 	if msg.CosmosSender.Empty() {

--- a/x/ethbridge/types/msgs.go
+++ b/x/ethbridge/types/msgs.go
@@ -140,15 +140,13 @@ func (msg MsgBurn) ValidateBasic() error {
 	if len(msg.Symbol) <= 0 {
 		return ErrInvalidSymbol
 	}
-	symbolSplit := strings.Split(msg.Symbol, "::")
-	if len(symbolSplit) != 3 {
+	symbolPrefix := msg.Symbol[:8]
+	if symbolPrefix != PeggedCoinPrefix {
 		return ErrInvalidBurnSymbol
 	}
-	if symbolSplit[0] != "peg" {
-		return ErrInvalidBurnSymbol
-	}
-	if !gethCommon.IsHexAddress(symbolSplit[1]) {
-		return ErrInvalidBurnSymbol
+	symbolSuffix := msg.Symbol[8:]
+	if len(symbolSuffix) <= 0 {
+		return ErrInvalidSymbol
 	}
 	return nil
 }

--- a/x/ethbridge/types/msgs.go
+++ b/x/ethbridge/types/msgs.go
@@ -90,7 +90,6 @@ type MsgBurn struct {
 	Amount           int64           `json:"amount" yaml:"amount"`
 	Symbol           string          `json:"symbol" yaml:"symbol"`
 	EthereumChainID  int             `json:"ethereum_chain_id" yaml:"ethereum_chain_id"`
-	TokenContract    EthereumAddress `json:"token_contract_address" yaml:"token_contract_address"`
 	EthereumReceiver EthereumAddress `json:"ethereum_receiver" yaml:"ethereum_receiver"`
 }
 
@@ -117,12 +116,6 @@ func (msg MsgBurn) Type() string { return "burn" }
 func (msg MsgBurn) ValidateBasic() error {
 	if strconv.Itoa(msg.EthereumChainID) == "" {
 		return sdkerrors.Wrapf(ErrInvalidEthereumChainID, "%d", msg.EthereumChainID)
-	}
-	if msg.TokenContract.String() == "" {
-		return ErrInvalidEthAddress
-	}
-	if !gethCommon.IsHexAddress(msg.TokenContract.String()) {
-		return ErrInvalidEthAddress
 	}
 	if msg.CosmosSender.Empty() {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidAddress, msg.CosmosSender.String())
@@ -198,6 +191,9 @@ func (msg MsgCreateEthBridgeClaim) ValidateBasic() error {
 		return ErrInvalidEthAddress
 	}
 	if !gethCommon.IsHexAddress(msg.BridgeContractAddress.String()) {
+		return ErrInvalidEthAddress
+	}
+	if !gethCommon.IsHexAddress(msg.TokenContractAddress.String()) {
 		return ErrInvalidEthAddress
 	}
 	if strings.ToLower(msg.Symbol) == "eth" &&

--- a/x/ethbridge/types/msgs.go
+++ b/x/ethbridge/types/msgs.go
@@ -62,7 +62,7 @@ func (msg MsgLock) ValidateBasic() error {
 		return ErrInvalidAmount
 	}
 
-	if len(msg.Symbol) <= 0 {
+	if len(msg.Symbol) == 0 {
 		return ErrInvalidSymbol
 	}
 
@@ -96,11 +96,10 @@ type MsgBurn struct {
 
 // NewMsgBurn is a constructor function for MsgBurn
 func NewMsgBurn(
-	ethereumChainID int, tokenContract EthereumAddress, cosmosSender sdk.AccAddress,
+	ethereumChainID int, cosmosSender sdk.AccAddress,
 	ethereumReceiver EthereumAddress, amount int64, symbol string) MsgBurn {
 	return MsgBurn{
 		EthereumChainID:  ethereumChainID,
-		TokenContract:    tokenContract,
 		CosmosSender:     cosmosSender,
 		EthereumReceiver: ethereumReceiver,
 		Amount:           amount,
@@ -137,16 +136,17 @@ func (msg MsgBurn) ValidateBasic() error {
 	if msg.Amount <= 0 {
 		return ErrInvalidAmount
 	}
-	if len(msg.Symbol) <= 0 {
-		return ErrInvalidSymbol
+	prefixLength := len(PeggedCoinPrefix)
+	if len(msg.Symbol) <= prefixLength+1 {
+		return ErrInvalidBurnSymbol
 	}
-	symbolPrefix := msg.Symbol[:8]
+	symbolPrefix := msg.Symbol[:prefixLength]
 	if symbolPrefix != PeggedCoinPrefix {
 		return ErrInvalidBurnSymbol
 	}
-	symbolSuffix := msg.Symbol[8:]
-	if len(symbolSuffix) <= 0 {
-		return ErrInvalidSymbol
+	symbolSuffix := msg.Symbol[prefixLength:]
+	if len(symbolSuffix) == 0 {
+		return ErrInvalidBurnSymbol
 	}
 	return nil
 }

--- a/x/ethbridge/types/test_common.go
+++ b/x/ethbridge/types/test_common.go
@@ -53,10 +53,9 @@ func CreateTestEthClaim(
 
 func CreateTestBurnMsg(t *testing.T, testCosmosSender string, ethereumReceiver EthereumAddress,
 	coinsAmount int64, coinsSymbol string) MsgBurn {
-	testTokenContractAddress := NewEthereumAddress(TestTokenContractAddress)
 	testCosmosAddress, err := sdk.AccAddressFromBech32(TestAddress)
 	require.NoError(t, err)
-	burnEth := NewMsgBurn(TestEthereumChainID, testTokenContractAddress, testCosmosAddress, ethereumReceiver, coinsAmount, coinsSymbol)
+	burnEth := NewMsgBurn(TestEthereumChainID, testCosmosAddress, ethereumReceiver, coinsAmount, coinsSymbol)
 	return burnEth
 }
 
@@ -66,8 +65,8 @@ func CreateTestQueryEthProphecyResponse(
 	testEthereumAddress := NewEthereumAddress(TestEthereumAddress)
 	testContractAddress := NewEthereumAddress(TestBridgeContractAddress)
 	testTokenAddress := NewEthereumAddress(TestTokenContractAddress)
-	ethBridgeClaim := CreateTestEthClaim(
-		t, testContractAddress, testTokenAddress, validatorAddress, testEthereumAddress, TestCoinsAmount, TestCoinsSymbol, claimType)
+	ethBridgeClaim := CreateTestEthClaim(t, testContractAddress, testTokenAddress, validatorAddress,
+		testEthereumAddress, TestCoinsAmount, TestCoinsSymbol, claimType)
 	oracleClaim, _ := CreateOracleClaimFromEthClaim(cdc, ethBridgeClaim)
 	ethBridgeClaims := []EthBridgeClaim{ethBridgeClaim}
 

--- a/x/ethbridge/types/test_common.go
+++ b/x/ethbridge/types/test_common.go
@@ -17,12 +17,14 @@ const (
 	TestAddress               = "cosmos1gn8409qq9hnrxde37kuxwx5hrxpfpv8426szuv"
 	TestValidator             = "cosmos1xdp5tvt7lxh8rf9xx07wy2xlagzhq24ha48xtq"
 	TestNonce                 = 0
-	TestSymbol                = "eth"
 	TestTokenContractAddress  = "0x0000000000000000000000000000000000000000"
 	TestEthereumAddress       = "0x7B95B6EC7EbD73572298cEf32Bb54FA408207359"
 	AltTestEthereumAddress    = "0x7B95B6EC7EbD73572298cEf32Bb54FA408207344"
-	TestCoins                 = "10ethereum"
-	AltTestCoins              = "12ethereum"
+	TestCoinsAmount           = 10
+	TestCoinsSymbol           = "eth"
+	TestCoinsLockedSymbol     = "peggyeth"
+	AltTestCoinsAmount        = 12
+	AltTestCoinsSymbol        = "eth"
 )
 
 //Ethereum-bridge specific stuff
@@ -32,32 +34,29 @@ func CreateTestEthMsg(t *testing.T, validatorAddress sdk.ValAddress, claimType C
 	testTokenAddress := NewEthereumAddress(TestTokenContractAddress)
 	ethClaim := CreateTestEthClaim(
 		t, testContractAddress, testTokenAddress, validatorAddress,
-		testEthereumAddress, TestCoins, claimType)
+		testEthereumAddress, TestCoinsAmount, TestCoinsSymbol, claimType)
 	ethMsg := NewMsgCreateEthBridgeClaim(ethClaim)
 	return ethMsg
 }
 
 func CreateTestEthClaim(
 	t *testing.T, testContractAddress EthereumAddress, testTokenAddress EthereumAddress,
-	validatorAddress sdk.ValAddress, testEthereumAddress EthereumAddress, coins string, claimType ClaimType,
+	validatorAddress sdk.ValAddress, testEthereumAddress EthereumAddress, amount int64, symbol string, claimType ClaimType,
 ) EthBridgeClaim {
 	testCosmosAddress, err1 := sdk.AccAddressFromBech32(TestAddress)
-	amount, err2 := sdk.ParseCoins(coins)
 	require.NoError(t, err1)
-	require.NoError(t, err2)
 	ethClaim := NewEthBridgeClaim(
-		TestEthereumChainID, testContractAddress, TestNonce, TestSymbol,
+		TestEthereumChainID, testContractAddress, TestNonce, symbol,
 		testTokenAddress, testEthereumAddress, testCosmosAddress, validatorAddress, amount, claimType)
 	return ethClaim
 }
 
-func CreateTestBurnMsg(t *testing.T, testCosmosSender string, ethereumReceiver EthereumAddress, coins string) MsgBurn {
+func CreateTestBurnMsg(t *testing.T, testCosmosSender string, ethereumReceiver EthereumAddress,
+	coinsAmount int64, coinsSymbol string) MsgBurn {
 	testTokenContractAddress := NewEthereumAddress(TestTokenContractAddress)
 	testCosmosAddress, err := sdk.AccAddressFromBech32(TestAddress)
 	require.NoError(t, err)
-	amount, err := sdk.ParseCoins(coins)
-	require.NoError(t, err)
-	burnEth := NewMsgBurn(TestEthereumChainID, testTokenContractAddress, testCosmosAddress, ethereumReceiver, amount)
+	burnEth := NewMsgBurn(TestEthereumChainID, testTokenContractAddress, testCosmosAddress, ethereumReceiver, coinsAmount, coinsSymbol)
 	return burnEth
 }
 
@@ -68,7 +67,7 @@ func CreateTestQueryEthProphecyResponse(
 	testContractAddress := NewEthereumAddress(TestBridgeContractAddress)
 	testTokenAddress := NewEthereumAddress(TestTokenContractAddress)
 	ethBridgeClaim := CreateTestEthClaim(
-		t, testContractAddress, testTokenAddress, validatorAddress, testEthereumAddress, TestCoins, claimType)
+		t, testContractAddress, testTokenAddress, validatorAddress, testEthereumAddress, TestCoinsAmount, TestCoinsSymbol, claimType)
 	oracleClaim, _ := CreateOracleClaimFromEthClaim(cdc, ethBridgeClaim)
 	ethBridgeClaims := []EthBridgeClaim{ethBridgeClaim}
 


### PR DESCRIPTION
Partially Closes: #123  (Relayer and Solidity code still TODO)

This PR modifies the cosmos modules/sdk-related code to remove support for whitelisted tokens. 
 - Token contract address is no longer part of the burn/lock APIs.
 - Tokens minted when coming from Ethereum through lockups on Ethereum are minted with the 'peggy' prefix
 - Tokens being burned, to be sent back to Ethereum, need to have the 'peggy' prefix. Normal cosmos tokens can no longer be burned
 - CLI/APIs now use separate fields for amount and symbol, rather than a single field

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
