### PR TITLE
encodePacked -> encode and cleanup

### DIFF
--- a/solidity/contracts/HashingTest.sol
+++ b/solidity/contracts/HashingTest.sol
@@ -17,7 +17,7 @@ contract HashingTest {
 		// bytes32 encoding of the string "checkpoint"
 		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
 
-		bytes32 checkpoint = keccak256(abi.encodePacked(_peggyId, methodName, _valsetNonce));
+		bytes32 checkpoint = keccak256(abi.encode(_peggyId, methodName, _valsetNonce));
 
 		// Iterative hashing of valset
 		{
@@ -30,7 +30,7 @@ contract HashingTest {
 						"Validator power must not be higher than previous validator in batch"
 					);
 				}
-				checkpoint = keccak256(abi.encodePacked(checkpoint, _validators[i], _powers[i]));
+				checkpoint = keccak256(abi.encode(checkpoint, _validators[i], _powers[i]));
 			}
 		}
 
@@ -46,13 +46,13 @@ contract HashingTest {
 		// bytes32 encoding of the string "checkpoint"
 		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
 
-		bytes32 idHash = keccak256(abi.encodePacked(_peggyId, methodName, _valsetNonce));
+		bytes32 idHash = keccak256(abi.encode(_peggyId, methodName, _valsetNonce));
 
-		bytes32 validatorHash = keccak256(abi.encodePacked(_validators));
+		bytes32 validatorHash = keccak256(abi.encode(_validators));
 
-		bytes32 powersHash = keccak256(abi.encodePacked(_powers));
+		bytes32 powersHash = keccak256(abi.encode(_powers));
 
-		bytes32 checkpoint = keccak256(abi.encodePacked(idHash, validatorHash, powersHash));
+		bytes32 checkpoint = keccak256(abi.encode(idHash, validatorHash, powersHash));
 
 		lastCheckpoint = checkpoint;
 	}
@@ -66,9 +66,17 @@ contract HashingTest {
 		// bytes32 encoding of the string "checkpoint"
 		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
 
-		bytes32 checkpoint = keccak256(
-			abi.encodePacked(_peggyId, methodName, _valsetNonce, _validators, _powers)
+		bytes memory abiEncoded = abi.encode(
+			_peggyId,
+			methodName,
+			_valsetNonce,
+			_validators,
+			_powers
 		);
+
+		// console.logBytes(abiEncoded);
+
+		bytes32 checkpoint = keccak256(abiEncoded);
 
 		lastCheckpoint = checkpoint;
 	}

--- a/solidity/contracts/HashingTest.sol
+++ b/solidity/contracts/HashingTest.sol
@@ -74,8 +74,6 @@ contract HashingTest {
 			_powers
 		);
 
-		// console.logBytes(abiEncoded);
-
 		bytes32 checkpoint = keccak256(abiEncoded);
 
 		lastCheckpoint = checkpoint;

--- a/solidity/contracts/HashingTest.sol
+++ b/solidity/contracts/HashingTest.sol
@@ -66,15 +66,9 @@ contract HashingTest {
 		// bytes32 encoding of the string "checkpoint"
 		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
 
-		bytes memory abiEncoded = abi.encode(
-			_peggyId,
-			methodName,
-			_valsetNonce,
-			_validators,
-			_powers
+		bytes32 checkpoint = keccak256(
+			abi.encode(_peggyId, methodName, _valsetNonce, _validators, _powers)
 		);
-
-		bytes32 checkpoint = keccak256(abiEncoded);
 
 		lastCheckpoint = checkpoint;
 	}

--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -78,7 +78,7 @@ contract Peggy {
 		uint256[] memory _powers,
 		uint256 _valsetNonce,
 		bytes32 _peggyId
-	) public view returns (bytes32) {
+	) public pure returns (bytes32) {
 		// bytes32 encoding of the string "checkpoint"
 		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
 
@@ -100,7 +100,7 @@ contract Peggy {
 		// This is what we are checking they have signed
 		bytes32 _theHash,
 		uint256 _powerThreshold
-	) public view {
+	) public pure {
 		uint256 cumulativePower = 0;
 
 		for (uint256 k = 0; k < _currentValidators.length; k = k.add(1)) {

--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -268,17 +268,11 @@ contract Peggy {
 
 		// bytes32 encoding of "transactionBatch"
 		bytes32 methodName = 0x7472616e73616374696f6e426174636800000000000000000000000000000000;
-		bytes memory abiEncoded = abi.encode(
-			state_peggyId,
-			methodName,
-			_amounts,
-			_destinations,
-			_fees,
-			_nonces
-		);
 
 		// Get hash of the transaction batch
-		bytes32 transactionsHash = keccak256(abiEncoded);
+		bytes32 transactionsHash = keccak256(
+			abi.encode(state_peggyId, methodName, _amounts, _destinations, _fees, _nonces)
+		);
 
 		// Check that enough current validators have signed off on the transaction batch
 		checkValidatorSignatures(

--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -78,13 +78,21 @@ contract Peggy {
 		uint256[] memory _powers,
 		uint256 _valsetNonce,
 		bytes32 _peggyId
-	) public pure returns (bytes32) {
+	) public view returns (bytes32) {
 		// bytes32 encoding of the string "checkpoint"
 		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
 
-		bytes32 checkpoint = keccak256(
-			abi.encodePacked(_peggyId, methodName, _valsetNonce, _validators, _powers)
+		bytes memory abiEncoded = abi.encode(
+			_peggyId,
+			methodName,
+			_valsetNonce,
+			_validators,
+			_powers
 		);
+
+		// console.logBytes(abiEncoded);
+
+		bytes32 checkpoint = keccak256(abiEncoded);
 
 		return checkpoint;
 	}
@@ -185,7 +193,7 @@ contract Peggy {
 			state_peggyId
 		);
 
-		console.log("calling checkValidatorSignatures from updateValset");
+		// console.log("calling checkValidatorSignatures from updateValset");
 		checkValidatorSignatures(
 			_currentValidators,
 			_currentPowers,
@@ -272,10 +280,18 @@ contract Peggy {
 
 		// bytes32 encoding of "transactionBatch"
 		bytes32 methodName = 0x7472616e73616374696f6e426174636800000000000000000000000000000000;
-		// Get hash of the transaction batch
-		bytes32 transactionsHash = keccak256(
-			abi.encodePacked(state_peggyId, methodName, _amounts, _destinations, _fees, _nonces)
+		bytes memory abiEncoded = abi.encode(
+			state_peggyId,
+			methodName,
+			_amounts,
+			_destinations,
+			_fees,
+			_nonces
 		);
+
+		// console.logBytes(abiEncoded);
+		// Get hash of the transaction batch
+		bytes32 transactionsHash = keccak256(abiEncoded);
 
 		// Check that enough current validators have signed off on the transaction batch
 		checkValidatorSignatures(
@@ -344,7 +360,7 @@ contract Peggy {
 			_v,
 			_r,
 			_s,
-			keccak256(abi.encodePacked(newCheckpoint, _tokenContract, _peggyId, _powerThreshold)),
+			keccak256(abi.encode(newCheckpoint, _tokenContract, _peggyId, _powerThreshold)),
 			_powerThreshold
 		);
 

--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -82,17 +82,9 @@ contract Peggy {
 		// bytes32 encoding of the string "checkpoint"
 		bytes32 methodName = 0x636865636b706f696e7400000000000000000000000000000000000000000000;
 
-		bytes memory abiEncoded = abi.encode(
-			_peggyId,
-			methodName,
-			_valsetNonce,
-			_validators,
-			_powers
+		bytes32 checkpoint = keccak256(
+			abi.encode(_peggyId, methodName, _valsetNonce, _validators, _powers)
 		);
-
-		// console.logBytes(abiEncoded);
-
-		bytes32 checkpoint = keccak256(abiEncoded);
 
 		return checkpoint;
 	}
@@ -112,8 +104,6 @@ contract Peggy {
 		uint256 cumulativePower = 0;
 
 		for (uint256 k = 0; k < _currentValidators.length; k = k.add(1)) {
-			// console.log("verifying validator: ", k);
-			// console.log("with power: ", _currentPowers[k]);
 			// Check that the current validator has signed off on the hash
 			require(
 				verifySig(_currentValidators[k], _theHash, _v[k], _r[k], _s[k]),
@@ -125,7 +115,6 @@ contract Peggy {
 
 			// Break early to avoid wasting gas
 			if (cumulativePower > _powerThreshold) {
-				// console.log("number of validator sigs verified:", k + 1);
 				break;
 			}
 		}
@@ -193,7 +182,6 @@ contract Peggy {
 			state_peggyId
 		);
 
-		// console.log("calling checkValidatorSignatures from updateValset");
 		checkValidatorSignatures(
 			_currentValidators,
 			_currentPowers,
@@ -289,7 +277,6 @@ contract Peggy {
 			_nonces
 		);
 
-		// console.logBytes(abiEncoded);
 		// Get hash of the transaction batch
 		bytes32 transactionsHash = keccak256(abiEncoded);
 

--- a/solidity/contracts/SigningTest.sol
+++ b/solidity/contracts/SigningTest.sol
@@ -2,15 +2,15 @@ pragma solidity ^0.6.6;
 
 import "@nomiclabs/buidler/console.sol";
 
-
 contract SigningTest {
-	function checkSignature(address _signer, bytes32 _theHash, uint8 _v, bytes32 _r, bytes32 _s)
-		public
-		view
-	{
-		bytes32 messageDigest = keccak256(
-			abi.encodePacked("\x19Ethereum Signed Message:\n32", _theHash)
-		);
+	function checkSignature(
+		address _signer,
+		bytes32 _theHash,
+		uint8 _v,
+		bytes32 _r,
+		bytes32 _s
+	) public view {
+		bytes32 messageDigest = keccak256(abi.encode("\x19Ethereum Signed Message:\n32", _theHash));
 
 		console.log("signer");
 		console.logAddress(_signer);

--- a/solidity/test-utils/index.ts
+++ b/solidity/test-utils/index.ts
@@ -25,9 +25,18 @@ export async function deployContracts(
 
   const checkpoint = makeCheckpoint(valAddresses, powers, 0, peggyId);
 
-  const theHash = ethers.utils.solidityKeccak256(
-    ["bytes32", "address", "bytes32", "uint256"],
-    [checkpoint, testERC20.address, peggyId, powerThreshold]
+  // const theHash = ethers.utils.keccak256(
+  //   ethers.utils.defaultAbiCoder.encode(
+  //     ["bytes32", "address", "bytes32", "uint256"],
+  //     [checkpoint, testERC20.address, peggyId, powerThreshold]
+  //   )
+  // );
+
+  let theHash = ethers.utils.keccak256(
+    ethers.utils.defaultAbiCoder.encode(
+      ["bytes32", "address", "bytes32", "uint256"],
+      [checkpoint, testERC20.address, peggyId, powerThreshold]
+    )
   );
 
   const { v, r, s } = await signHash(validators, theHash);

--- a/solidity/test-utils/index.ts
+++ b/solidity/test-utils/index.ts
@@ -25,13 +25,6 @@ export async function deployContracts(
 
   const checkpoint = makeCheckpoint(valAddresses, powers, 0, peggyId);
 
-  // const theHash = ethers.utils.keccak256(
-  //   ethers.utils.defaultAbiCoder.encode(
-  //     ["bytes32", "address", "bytes32", "uint256"],
-  //     [checkpoint, testERC20.address, peggyId, powerThreshold]
-  //   )
-  // );
-
   let theHash = ethers.utils.keccak256(
     ethers.utils.defaultAbiCoder.encode(
       ["bytes32", "address", "bytes32", "uint256"],

--- a/solidity/test-utils/pure.ts
+++ b/solidity/test-utils/pure.ts
@@ -14,19 +14,10 @@ export function makeCheckpoint(
 ) {
   const methodName = ethers.utils.formatBytes32String("checkpoint");
 
-  // let checkpoint = ethers.utils.keccak256(
-  //   ethers.utils.defaultAbiCoder.encode(
-  //     ["bytes32", "bytes32", "uint256", "address[]", "uint256[]"],
-  //     [peggyId, methodName, valsetNonce, validators, powers]
-  //   )
-  // );
-
   let abiEncoded = ethers.utils.defaultAbiCoder.encode(
     ["bytes32", "bytes32", "uint256", "address[]", "uint256[]"],
     [peggyId, methodName, valsetNonce, validators, powers]
   );
-
-  // console.log("checkpoint abiEncoded", abiEncoded);
 
   let checkpoint = ethers.utils.keccak256(abiEncoded);
 
@@ -51,10 +42,6 @@ export async function signHash(signers: Signer[], hash: string) {
   return { v, r, s };
 }
 
-// bytes32 methodName = 0x7472616e73616374696f6e426174636800000000000000000000000000000000;
-// bytes32 transactionsHash = keccak256(
-//   abi.encode(peggyId, methodName, _amounts, _destinations, _fees, _nonces)
-// );
 export function makeTxBatchHash(
   amounts: number[],
   destinations: string[],
@@ -63,22 +50,6 @@ export function makeTxBatchHash(
   peggyId: string
 ) {
   const methodName = ethers.utils.formatBytes32String("transactionBatch");
-
-  // let txHash = ethers.utils.keccak256(
-  //   ethers.utils.defaultAbiCoder.encode(
-  //     [
-  //       "bytes32",
-  //       "bytes32",
-  //       "uint256[]",
-  //       "address[]",
-  //       "uint256[]",
-  //       "uint256[]"
-  //     ],
-  //     [peggyId, methodName, amounts, destinations, fees, nonces]
-  //   )
-  // );
-
-  // "tuple(bytes32 peggyId, bytes32 methodName, uint256[] amounts, address[] destinations, uint256[] fees, uint256[] nonces)"
 
   let abiEncoded = ethers.utils.defaultAbiCoder.encode(
     ["bytes32", "bytes32", "uint256[]", "address[]", "uint256[]", "uint256[]"],

--- a/solidity/test-utils/pure.ts
+++ b/solidity/test-utils/pure.ts
@@ -14,10 +14,21 @@ export function makeCheckpoint(
 ) {
   const methodName = ethers.utils.formatBytes32String("checkpoint");
 
-  let checkpoint = ethers.utils.solidityKeccak256(
+  // let checkpoint = ethers.utils.keccak256(
+  //   ethers.utils.defaultAbiCoder.encode(
+  //     ["bytes32", "bytes32", "uint256", "address[]", "uint256[]"],
+  //     [peggyId, methodName, valsetNonce, validators, powers]
+  //   )
+  // );
+
+  let abiEncoded = ethers.utils.defaultAbiCoder.encode(
     ["bytes32", "bytes32", "uint256", "address[]", "uint256[]"],
     [peggyId, methodName, valsetNonce, validators, powers]
   );
+
+  // console.log("checkpoint abiEncoded", abiEncoded);
+
+  let checkpoint = ethers.utils.keccak256(abiEncoded);
 
   return checkpoint;
 }
@@ -42,7 +53,7 @@ export async function signHash(signers: Signer[], hash: string) {
 
 // bytes32 methodName = 0x7472616e73616374696f6e426174636800000000000000000000000000000000;
 // bytes32 transactionsHash = keccak256(
-//   abi.encodePacked(peggyId, methodName, _amounts, _destinations, _fees, _nonces)
+//   abi.encode(peggyId, methodName, _amounts, _destinations, _fees, _nonces)
 // );
 export function makeTxBatchHash(
   amounts: number[],
@@ -53,10 +64,30 @@ export function makeTxBatchHash(
 ) {
   const methodName = ethers.utils.formatBytes32String("transactionBatch");
 
-  let txHash = ethers.utils.solidityKeccak256(
+  // let txHash = ethers.utils.keccak256(
+  //   ethers.utils.defaultAbiCoder.encode(
+  //     [
+  //       "bytes32",
+  //       "bytes32",
+  //       "uint256[]",
+  //       "address[]",
+  //       "uint256[]",
+  //       "uint256[]"
+  //     ],
+  //     [peggyId, methodName, amounts, destinations, fees, nonces]
+  //   )
+  // );
+
+  // "tuple(bytes32 peggyId, bytes32 methodName, uint256[] amounts, address[] destinations, uint256[] fees, uint256[] nonces)"
+
+  let abiEncoded = ethers.utils.defaultAbiCoder.encode(
     ["bytes32", "bytes32", "uint256[]", "address[]", "uint256[]", "uint256[]"],
     [peggyId, methodName, amounts, destinations, fees, nonces]
   );
+
+  // console.log(abiEncoded);
+
+  let txHash = ethers.utils.keccak256(abiEncoded);
 
   return txHash;
 }

--- a/solidity/test/happy-path.ts
+++ b/solidity/test/happy-path.ts
@@ -31,10 +31,16 @@ describe("Peggy happy path", function() {
       checkpoint: deployCheckpoint
     } = await deployContracts(peggyId, validators, powers, powerThreshold);
 
-    expect(await peggy.functions.peggyId()).to.equal(peggyId);
-    expect(await peggy.functions.powerThreshold()).to.equal(powerThreshold);
-    expect(await peggy.functions.tokenContract()).to.equal(testERC20.address);
-    expect(await peggy.functions.lastCheckpoint()).to.equal(deployCheckpoint);
+    expect(await peggy.functions.state_peggyId()).to.equal(peggyId);
+    expect(await peggy.functions.state_powerThreshold()).to.equal(
+      powerThreshold
+    );
+    expect(await peggy.functions.state_tokenContract()).to.equal(
+      testERC20.address
+    );
+    expect(await peggy.functions.state_lastCheckpoint()).to.equal(
+      deployCheckpoint
+    );
 
     let newPowers = examplePowers();
     newPowers[0] -= 3;
@@ -65,7 +71,7 @@ describe("Peggy happy path", function() {
       sigs.s
     );
 
-    expect(await peggy.functions.lastCheckpoint()).to.equal(checkpoint);
+    expect(await peggy.functions.state_lastCheckpoint()).to.equal(checkpoint);
 
     // Transferring out to Cosmos
 

--- a/solidity/test/hashingTest.ts
+++ b/solidity/test/hashingTest.ts
@@ -70,10 +70,14 @@ export function makeCheckpoint(
 ) {
   const methodName = ethers.utils.formatBytes32String("checkpoint");
 
-  let checkpoint = ethers.utils.solidityKeccak256(
+  let abiEncoded = ethers.utils.defaultAbiCoder.encode(
     ["bytes32", "bytes32", "uint256", "address[]", "uint256[]"],
     [peggyId, methodName, valsetNonce, validators, powers]
   );
+
+  // console.log("abiEncoded", abiEncoded);
+
+  let checkpoint = ethers.utils.keccak256(abiEncoded);
 
   return checkpoint;
 }

--- a/solidity/test/hashingTest.ts
+++ b/solidity/test/hashingTest.ts
@@ -75,8 +75,6 @@ export function makeCheckpoint(
     [peggyId, methodName, valsetNonce, validators, powers]
   );
 
-  // console.log("abiEncoded", abiEncoded);
-
   let checkpoint = ethers.utils.keccak256(abiEncoded);
 
   return checkpoint;


### PR DESCRIPTION
This changes to using abi.encode instead of abi.encodePacked when hashing values. This is a less ambiguous encoding and will avoid hard-to-foresee exploits. It also does some cleanup of the code, most notably prefixing state variables with "state_" to avoid typos.