### PR TITLE
UpdateValset, SubmitBatch tests and writeup

### DIFF
--- a/solidity/contracts/HashingTest.sol
+++ b/solidity/contracts/HashingTest.sol
@@ -7,6 +7,9 @@ contract HashingTest {
 	using SafeMath for uint256;
 
 	bytes32 public lastCheckpoint;
+	address[] public state_validators;
+	uint256[] public state_powers;
+	uint256 public state_nonce;
 
 	function IterativeHash(
 		address[] memory _validators,
@@ -71,5 +74,25 @@ contract HashingTest {
 		);
 
 		lastCheckpoint = checkpoint;
+	}
+
+	function JustSaveEverything(
+		address[] memory _validators,
+		uint256[] memory _powers,
+		uint256 _valsetNonce
+	) public {
+		state_validators = _validators;
+		state_powers = _powers;
+		state_nonce = _valsetNonce;
+	}
+
+	function JustSaveEverythingAgain(
+		address[] memory _validators,
+		uint256[] memory _powers,
+		uint256 _valsetNonce
+	) public {
+		state_validators = _validators;
+		state_powers = _powers;
+		state_nonce = _valsetNonce;
 	}
 }

--- a/solidity/contracts/Peggy.sol
+++ b/solidity/contracts/Peggy.sol
@@ -100,7 +100,7 @@ contract Peggy {
 		// This is what we are checking they have signed
 		bytes32 _theHash,
 		uint256 _powerThreshold
-	) public view {
+	) public pure {
 		uint256 cumulativePower = 0;
 
 		for (uint256 k = 0; k < _currentValidators.length; k = k.add(1)) {
@@ -263,7 +263,7 @@ contract Peggy {
 			for (uint256 i = 0; i < _nonces.length; i = i.add(1)) {
 				require(
 					_nonces[i] > lastTxNonceTemp,
-					"Transaction nonces in batch must be strictly increasing"
+					"Transaction nonces in batch must be higher than last transaction nonce and strictly increasing"
 				);
 
 				lastTxNonceTemp = _nonces[i];

--- a/solidity/contracts/contract-explanation.md
+++ b/solidity/contracts/contract-explanation.md
@@ -32,4 +32,14 @@ At this point, all of the checks are complete, and it's time to update the valse
 
 ### SubmitBatch
 
+This is how the bridge transfers tokens from addresses on the Tendermint chain to addresses on the Ethereum chain. The Cosmos validators sign batches of transactions that are submitted to the contract. Each transaction has a destination address, an amount, a nonce, and a fee for whoever submitted the batch.
+
+We start with some of the same checks that are done in UpdateValset- checking that the lengths of the arrays match up, and checking the supplied current valset against the checkpoint. We then iterate over the transactions in the batch and check that their nonces are strictly increasing, and are higher than the nonces of the last batch submitted. This is done so that old batches cannot be resubmitted.
+
+We check the current validator's signatures over the hash of the transaction batch, using the same method used above to check their signatures over a new valset.
+
+Now we are ready to make the transfers. We first store the highest nonce in the batch to use next time. We then iterate over all the transactions in the batch and do the transfers. We also add up the fees and transfer them to msg.sender.
+
 ### TransferOut
+
+This is used to transfer tokens from an Ethereum address to a Tendermint address. It is extremely simple, because everything really happens on the Tendermint side. The transferred tokens are locked in the contract, then an event is emitted. The Tendermint validators see this event and mint tokens on the Tendermint side.

--- a/solidity/contracts/contract-explanation.md
+++ b/solidity/contracts/contract-explanation.md
@@ -1,0 +1,23 @@
+# Functioning of the Peggy.sol contract
+
+The Peggy contract locks assets on Ethereum to facilitate a Tendermint blockchain creating synthetic versions of those assets. It is designed to be used alongside software on the Tendermint blockchain, but this article focuses on the Ethereum side.
+
+Usage example:
+
+- You send 25 DAI to the Peggy contract, specifying which address on the Tendermint chain should recieve the syntehtic DAI.
+- Validators on the Tendermint chain see that this has happened and mint 25 synthetic DAI for the address you specified on the Tendermint chain.
+- You send the 25 synthetic DAI to Jim on the Tendermint chain.
+- Jim sends the synthetic DAI to Peggy module on the Tendermint chain, specifying which Ethereum address should receive it.
+- The Tendermint validators burn the synthetic DAI on the Tendermint chain and unlock 25 DAI for Jim on Ethereum
+
+## Security model
+
+The Peggy contract is basically a multisig with a few tweaks. Even though it is designed to be used with a consensus process on Tendermint, the Peggy contract itself encodes nothing about this consensus process. There are three main operations- UpdateValset, SubmitBatch, and TransferOut. UpdateValset updates the signers on the multisig, and their relative powers. This mirrors the validator set on the Tendermint chain, so that all the Tendermint validators are signers, in proportion to their staking power on the Tendermint chain. An UpdateValset transaction must be signed by 2/3's of the current valset to be accepted. SubmitBatch is used to submit a batch of transactions unlocking and transferring tokens to Ethereum addresses. It is used to send tokens from Cosmos to Ethereum. The batch must be signed by 2/3's of the current valset. TransferOut is used to send tokens onto the Tendermint chain. It simply locks the tokens in the contract and emits an event which is picked up by the Tendermint validators.
+
+### UpdateValset
+
+A valset consists of a list of validator's Ethereum addresses, their voting power, and a nonce for the entire valset. UpdateValset takes a new valset, the current valset, and the signatures of the current valset over the new valset. The valsets and the signatures are currently broken into separate arrays because it is not possible to pass arrays of structs into Solidity external functions. Because of this, UpdateValset first does a few checks to make sure that all the arrays that make up a valset are the same length.
+
+Then, it checks the supplied current valset against the saved checkpoint. This requires some explanation. Because valsets contain over 100 validators, storing these all on the Ethereum blockchain each time would be quite expensive. Because of this, we only store a hash of the current valset, then let the caller supply the actual addresses, powers, and nonce of the valset. We call this hash the checkpoint.
+
+Once we are sure that the valset supplied by the caller is the correct one, we

--- a/solidity/contracts/contract-explanation.md
+++ b/solidity/contracts/contract-explanation.md
@@ -18,6 +18,18 @@ The Peggy contract is basically a multisig with a few tweaks. Even though it is 
 
 A valset consists of a list of validator's Ethereum addresses, their voting power, and a nonce for the entire valset. UpdateValset takes a new valset, the current valset, and the signatures of the current valset over the new valset. The valsets and the signatures are currently broken into separate arrays because it is not possible to pass arrays of structs into Solidity external functions. Because of this, UpdateValset first does a few checks to make sure that all the arrays that make up a valset are the same length.
 
-Then, it checks the supplied current valset against the saved checkpoint. This requires some explanation. Because valsets contain over 100 validators, storing these all on the Ethereum blockchain each time would be quite expensive. Because of this, we only store a hash of the current valset, then let the caller supply the actual addresses, powers, and nonce of the valset. We call this hash the checkpoint.
+Then, it checks the supplied current valset against the saved checkpoint. This requires some explanation. Because valsets contain over 100 validators, storing these all on the Ethereum blockchain each time would be quite expensive. Because of this, we only store a hash of the current valset, then let the caller supply the actual addresses, powers, and nonce of the valset. We call this hash the checkpoint. This is done with the function makeCheckpoint.
 
-Once we are sure that the valset supplied by the caller is the correct one, we
+Once we are sure that the valset supplied by the caller is the correct one, we check that the new valset nonce is higher than current valset nonce (NOTE: It is still not entirely clear to us whether this rule should instead check that the nonce is incremented by exactly one). This ensures that old valsets cannot be submitted because their nonce is too low.
+
+Now, we make a checkpoint from the submitted new valset, using makeCheckpoint again. In addition to be used as a checkpoint later on, we first use it as a digest to check the current valset's signature over the new valset. We use checkValidatorSignatures to do this.
+
+CheckValidatorSignatures takes a valset, an array of signatures, a hash, and a power threshold. It checks that the powers of all the validators that have signed the hash add up to the threshold. This is how we know that the new valset has been approved by at least 2/3s of the current valset. We iterate over the current valset and the array of signatures, which should be the same length. For each validator, we first check if the signature is all zeros. This signifies that it was not possible to obtain the signature of a given validator. If this is the case, we just skip to the next validator in the list. Since we only need 2/3s of the signatures, it is not required that every validator sign every time, and skipping them stops any validator from being able to stop the bridge.
+
+If we have a signature for a validator, we verify it, throwing an error if there is something wrong. We also increment a cumulativePower counter with the validator's power. Once this is over the threshold, we break out of the loop, and the signatures have been verified! If the loop ends without the threshold being met, we throw an error. Because of the way we break out of the loop once the threshold has been met, if the valset is sorted by descending power, we can usually skip evaluating the majority of signatures. To take advantage of this gas savings, it is important that valsets be produced by the validators in descending order of power.
+
+At this point, all of the checks are complete, and it's time to update the valset! This is a bit anticlimactic, since all we do is save the new checkpoint over the old one. An event is also emitted.
+
+### SubmitBatch
+
+### TransferOut

--- a/solidity/test/constructor.ts
+++ b/solidity/test/constructor.ts
@@ -59,6 +59,8 @@ describe("constructor tests", function() {
 
     await expect(
       deployContracts(peggyId, validators, powers, powerThreshold)
-    ).to.be.revertedWith("Submitted validator set does not have enough power");
+    ).to.be.revertedWith(
+      "Submitted validator set signatures do not have enough power"
+    );
   });
 });

--- a/solidity/test/hashingTest.ts
+++ b/solidity/test/hashingTest.ts
@@ -10,7 +10,7 @@ import { getSignerAddresses } from "../test-utils/pure";
 chai.use(solidity);
 const { expect } = chai;
 
-describe("Hashing test", function() {
+describe.only("Hashing test", function() {
   it("Hashing test", async function() {
     const signers = await ethers.getSigners();
     const peggyId = ethers.utils.formatBytes32String("foo");
@@ -59,6 +59,18 @@ describe("Hashing test", function() {
     );
 
     expect(contractCheckpoint === externalCheckpoint);
+
+    await hashingContract.JustSaveEverything(
+      await getSignerAddresses(validators),
+      powers,
+      1
+    );
+
+    await hashingContract.JustSaveEverythingAgain(
+      await getSignerAddresses(validators),
+      powers,
+      1
+    );
   });
 });
 

--- a/solidity/test/hashingTest.ts
+++ b/solidity/test/hashingTest.ts
@@ -10,7 +10,7 @@ import { getSignerAddresses } from "../test-utils/pure";
 chai.use(solidity);
 const { expect } = chai;
 
-describe.only("Hashing test", function() {
+describe("Hashing test", function() {
   it("Hashing test", async function() {
     const signers = await ethers.getSigners();
     const peggyId = ethers.utils.formatBytes32String("foo");

--- a/solidity/test/submitBatch.ts
+++ b/solidity/test/submitBatch.ts
@@ -1,0 +1,183 @@
+import chai from "chai";
+import { ethers } from "@nomiclabs/buidler";
+import { solidity } from "ethereum-waffle";
+
+import { deployContracts } from "../test-utils";
+import {
+  getSignerAddresses,
+  makeCheckpoint,
+  signHash,
+  makeTxBatchHash,
+  examplePowers
+} from "../test-utils/pure";
+
+chai.use(solidity);
+const { expect } = chai;
+
+async function runTest(opts: {
+  malformedCurrentValset?: boolean;
+  malformedTxBatch?: boolean;
+  nonMatchingCurrentValset?: boolean;
+  nonceNotHigher?: boolean;
+  nonceNotIncreasing?: boolean;
+  badValidatorSig?: boolean;
+  zeroedValidatorSig?: boolean;
+  notEnoughPower?: boolean;
+}) {
+  const signers = await ethers.getSigners();
+  const peggyId = ethers.utils.formatBytes32String("foo");
+
+  // This is the power distribution on the Cosmos hub as of 7/14/2020
+  let powers = examplePowers();
+  let validators = signers.slice(0, powers.length);
+
+  if (opts.malformedCurrentValset) {
+    validators = signers.slice(0, powers.length + 1);
+  }
+
+  const powerThreshold = 6666;
+
+  const {
+    peggy,
+    testERC20,
+    checkpoint: deployCheckpoint
+  } = await deployContracts(peggyId, validators, powers, powerThreshold);
+
+  // Transferring out to Cosmos
+
+  await testERC20.functions.approve(peggy.address, 1000);
+
+  await peggy.functions.transferOut(
+    ethers.utils.formatBytes32String("myCosmosAddress"),
+    1000
+  );
+
+  const txDestinationsInt = new Array(100);
+  const txFees = new Array(100);
+  const txNonces = new Array(100);
+  const txAmounts = new Array(100);
+  for (let i = 0; i < 100; i++) {
+    txNonces[i] = i + 1;
+    if (opts.nonceNotHigher) {
+      txNonces[i] = i;
+    }
+    if (opts.nonceNotIncreasing) {
+      txNonces[i] = 1;
+    }
+    txFees[i] = 1;
+    txAmounts[i] = 1;
+    txDestinationsInt[i] = signers[i + 5];
+  }
+  // Transferring into ERC20 from Cosmos
+  const txDestinations = await getSignerAddresses(txDestinationsInt);
+
+  if (opts.malformedTxBatch) {
+    txFees.pop();
+  }
+
+  let currentValsetNonce = 0;
+  if (opts.nonMatchingCurrentValset) {
+    currentValsetNonce = 420;
+  }
+
+  let txHash = makeTxBatchHash(
+    txAmounts,
+    txDestinations,
+    txFees,
+    txNonces,
+    peggyId
+  );
+
+  let sigs = await signHash(validators, txHash);
+  if (opts.badValidatorSig) {
+    // Switch the first sig for the second sig to screw things up
+    sigs.v[1] = sigs.v[0];
+    sigs.r[1] = sigs.r[0];
+    sigs.s[1] = sigs.s[0];
+  }
+
+  if (opts.zeroedValidatorSig) {
+    // Switch the first sig for the second sig to screw things up
+    sigs.v[1] = sigs.v[0];
+    sigs.r[1] = sigs.r[0];
+    sigs.s[1] = sigs.s[0];
+    // Then zero it out to skip evaluation
+    sigs.v[1] = 0;
+  }
+
+  if (opts.notEnoughPower) {
+    // zero out enough signatures that we dip below the threshold
+    sigs.v[1] = 0;
+    sigs.v[2] = 0;
+    sigs.v[3] = 0;
+    sigs.v[5] = 0;
+    sigs.v[6] = 0;
+    sigs.v[7] = 0;
+    sigs.v[9] = 0;
+    sigs.v[11] = 0;
+    sigs.v[13] = 0;
+  }
+
+  await peggy.submitBatch(
+    await getSignerAddresses(validators),
+    powers,
+    currentValsetNonce,
+    sigs.v,
+    sigs.r,
+    sigs.s,
+    txAmounts,
+    txDestinations,
+    txFees,
+    txNonces
+  );
+}
+
+describe("submitBatch tests", function() {
+  it("throws on malformed current valset", async function() {
+    await expect(runTest({ malformedCurrentValset: true })).to.be.revertedWith(
+      "Malformed current validator set"
+    );
+  });
+
+  it("throws on malformed txbatch", async function() {
+    await expect(runTest({ malformedTxBatch: true })).to.be.revertedWith(
+      "Malformed batch of transactions"
+    );
+  });
+
+  it("throws on non matching checkpoint for current valset", async function() {
+    await expect(
+      runTest({ nonMatchingCurrentValset: true })
+    ).to.be.revertedWith(
+      "Supplied current validators and powers do not match checkpoint"
+    );
+  });
+
+  it("throws on tx nonces not high enough", async function() {
+    await expect(runTest({ nonceNotHigher: true })).to.be.revertedWith(
+      "Transaction nonces in batch must be higher than last transaction nonce and strictly increasing"
+    );
+  });
+
+  it("throws on tx nonces not strictly increasing", async function() {
+    await expect(runTest({ nonceNotIncreasing: true })).to.be.revertedWith(
+      "Transaction nonces in batch must be higher than last transaction nonce and strictly increasing"
+    );
+  });
+
+  it("throws on bad validator sig", async function() {
+    await expect(runTest({ badValidatorSig: true })).to.be.revertedWith(
+      "Validator signature does not match"
+    );
+  });
+
+  it("allows zeroed sig", async function() {
+    await runTest({ zeroedValidatorSig: true });
+  });
+
+  it("throws on not enough signatures", async function() {
+    await expect(runTest({ notEnoughPower: true })).to.be.revertedWith(
+      "Submitted validator set signatures do not have enough power"
+    );
+  });
+});

--- a/solidity/test/updateValset.ts
+++ b/solidity/test/updateValset.ts
@@ -1,0 +1,123 @@
+import chai from "chai";
+import { ethers } from "@nomiclabs/buidler";
+import { solidity } from "ethereum-waffle";
+
+import { deployContracts } from "../test-utils";
+import {
+  getSignerAddresses,
+  makeCheckpoint,
+  signHash,
+  makeTxBatchHash,
+  examplePowers
+} from "../test-utils/pure";
+
+chai.use(solidity);
+const { expect } = chai;
+
+async function runTest(opts: {
+  malformedNewValset?: boolean;
+  malformedCurrentValset?: boolean;
+  nonMatchingCurrentValset?: boolean;
+  nonceNotIncremented?: boolean;
+  badValidatorSig?: boolean;
+}) {
+  const signers = await ethers.getSigners();
+  const peggyId = ethers.utils.formatBytes32String("foo");
+
+  // This is the power distribution on the Cosmos hub as of 7/14/2020
+  let powers = examplePowers();
+  let validators = signers.slice(0, powers.length);
+
+  const powerThreshold = 6666;
+
+  const {
+    peggy,
+    testERC20,
+    checkpoint: deployCheckpoint
+  } = await deployContracts(peggyId, validators, powers, powerThreshold);
+
+  let newPowers = examplePowers();
+  newPowers[0] -= 3;
+  newPowers[1] += 3;
+
+  let newValidators = signers.slice(0, newPowers.length);
+  if (opts.malformedNewValset) {
+    // Validators and powers array don't match
+    newValidators = signers.slice(0, newPowers.length - 1);
+  }
+
+  let currentValsetNonce = 0;
+  if (opts.nonMatchingCurrentValset) {
+    currentValsetNonce = 420;
+  }
+  let newValsetNonce = 1;
+  if (opts.nonceNotIncremented) {
+    newValsetNonce = 420;
+  }
+
+  const checkpoint = makeCheckpoint(
+    await getSignerAddresses(newValidators),
+    newPowers,
+    newValsetNonce,
+    peggyId
+  );
+
+  let sigs = await signHash(validators, checkpoint);
+  if (opts.badValidatorSig) {
+    // Switch the first sig for the second sig to screw things up
+    sigs.v[1] = sigs.v[0];
+    sigs.r[1] = sigs.r[0];
+    sigs.s[1] = sigs.s[0];
+  }
+
+  if (opts.malformedCurrentValset) {
+    // Remove one of the powers to make the length not match
+    powers.pop();
+  }
+
+  return peggy.updateValset(
+    await getSignerAddresses(newValidators),
+    newPowers,
+    newValsetNonce,
+    await getSignerAddresses(validators),
+    powers,
+    currentValsetNonce,
+    sigs.v,
+    sigs.r,
+    sigs.s
+  );
+}
+
+describe("updateValset tests", function() {
+  it("throws on malformed new valset", async function() {
+    await expect(runTest({ malformedNewValset: true })).to.be.revertedWith(
+      "Malformed new validator set"
+    );
+  });
+
+  it("throws on malformed current valset", async function() {
+    await expect(runTest({ malformedCurrentValset: true })).to.be.revertedWith(
+      "Malformed current validator set"
+    );
+  });
+
+  it("throws on non matching checkpoint for current valset", async function() {
+    await expect(
+      runTest({ nonMatchingCurrentValset: true })
+    ).to.be.revertedWith(
+      "Supplied current validators and powers do not match checkpoint"
+    );
+  });
+
+  it("throws on new valset nonce not incremented", async function() {
+    await expect(runTest({ nonceNotIncremented: true })).to.be.revertedWith(
+      "Valset nonce must be incremented by one"
+    );
+  });
+
+  it("throws on bad validator sig", async function() {
+    await expect(runTest({ badValidatorSig: true })).to.be.revertedWith(
+      "Validator signature does not match"
+    );
+  });
+});


### PR DESCRIPTION
This finishes the detailed UpdateValset and SubmitBatch tests, and adds a writeup explaining the contract. It also adds a gas test comparing just saving the entire valset instead of making a checkpoint.