### PR TITLE
Fix ebrelayer generate cmd throws ERROR: exit status 1

### DIFF
--- a/cmd/ebrelayer/contract/generator.go
+++ b/cmd/ebrelayer/contract/generator.go
@@ -10,6 +10,7 @@ const (
 	SolcCmdText   = "[SOLC_CMD]"
 	DirectoryText = "[DIRECTORY]"
 	ContractText  = "[CONTRACT]"
+	Dir           = "[Dir]"
 )
 
 var (
@@ -26,7 +27,7 @@ var (
 		fmt.Sprintf("--abi ./cmd/ebrelayer/contract/generated/abi/%s/%s.abi ", ContractText, ContractText),
 		fmt.Sprintf("--pkg %s ", ContractText),
 		fmt.Sprintf("--type %s ", ContractText),
-		fmt.Sprintf("--out ./cmd/ebrelayer/contract/generated/bindings/%s/%s.go", ContractText, ContractText)},
+		fmt.Sprintf("--out ./cmd/ebrelayer/contract/generated/bindings/%s/%s.go", Dir, ContractText)},
 		"")
 )
 
@@ -61,6 +62,7 @@ func CompileContracts(contracts BridgeContracts) error {
 func GenerateBindings(contracts BridgeContracts) error {
 	for _, contract := range contracts {
 		genBindingCmd := strings.Replace(BaseBindingGenCmd, ContractText, contract.String(), -1)
+		genBindingCmd = strings.Replace(genBindingCmd, Dir, strings.ToLower(contract.String()), -1)
 		err := execCmd(genBindingCmd)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

When I run ebrelayer generate, it throws ERROR: exit status 1. I discovered its reason in cmd/ebrelayer/contract/generator.go file. Because right path must be `bindings/bridgebank/BridgeBank.go`, therefor I used string.ToLower(contract.String()) and replace for Dir.  
______

For contributor use:

- [ x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [X ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
https://github.com/cosmos/peggy/issues/222
- [X ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).

