### PR TITLE
Fix race condition in tests

### DIFF
--- a/orchestrator/cosmos_peggy/src/lib.rs
+++ b/orchestrator/cosmos_peggy/src/lib.rs
@@ -4,8 +4,6 @@
 //! that's part of the Cosmos module.
 
 #[macro_use]
-extern crate serde_json;
-#[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate log;

--- a/orchestrator/cosmos_peggy/src/tests.rs
+++ b/orchestrator/cosmos_peggy/src/tests.rs
@@ -80,7 +80,7 @@ async fn test_valset_request_calls(
     // we request a valset be created
     // and then look at results at two block heights, one where the request was made, one where it
     // was not
-    let res = send_valset_request(&contact, key, fee.clone(), Duration::from_secs(60)).await;
+    let res = send_valset_request(&contact, key, fee.clone()).await;
     if res.is_err() {
         return Err(format!("Failed to create valset request {:?}", res));
     }

--- a/orchestrator/orchestrator/src/client.rs
+++ b/orchestrator/orchestrator/src/client.rs
@@ -112,7 +112,7 @@ async fn main() {
     let ethereum_public_key = ethereum_key.to_public_key().unwrap();
 
     info!("Sending in valset request");
-    let _res = send_valset_request(&contact, cosmos_key, fee, TIMEOUT)
+    let _res = send_valset_request(&contact, cosmos_key, fee)
         .await
         .expect("Failed to send valset request");
 


### PR DESCRIPTION
There was a race condition in the tests, since we are using a validator
address to send in the validator set request sometimes the orchestrator
running at the same time and using the same key, would update the nonce
in the middle of the validator set update operation. Causing a prepetual
failure as the sequence number was never refreshed.