### PR TITLE
WIP: Allow users to request arbitrary logic transactions

### DIFF
--- a/module/x/gravity/abci.go
+++ b/module/x/gravity/abci.go
@@ -266,31 +266,3 @@ func BatchSlashing(ctx sdk.Context, k keeper.Keeper, params types.Params) {
 
 	}
 }
-
-// TestingEndBlocker is a second endblocker function only imported in the Gravity codebase itself
-// if you are a consuming Cosmos chain DO NOT IMPORT THIS, it simulates a chain using the arbitrary
-// logic API to request logic calls
-func TestingEndBlocker(ctx sdk.Context, k keeper.Keeper) {
-	// if this is nil we have not set our test outgoing logic call yet
-	if k.GetOutgoingLogicCall(ctx, []byte("GravityTesting"), 0).Payload == nil {
-		// TODO this call isn't actually very useful for testing, since it always
-		// throws, being just junk data that's expected. But it prevents us from checking
-		// the full lifecycle of the call. We need to find some way for this to read data
-		// and encode a simple testing call, probably to one of the already deployed ERC20
-		// contracts so that we can get the full lifecycle.
-		token := []*types.ERC20Token{{
-			Contract: "0x7580bfe88dd3d07947908fae12d95872a260f2d8",
-			Amount:   sdk.NewIntFromUint64(5000),
-		}}
-		_ = types.OutgoingLogicCall{
-			Transfers:            token,
-			Fees:                 token,
-			LogicContractAddress: "0x510ab76899430424d209a6c9a5b9951fb8a6f47d",
-			Payload:              []byte("fake bytes"),
-			Timeout:              10000,
-			InvalidationId:       []byte("GravityTesting"),
-			InvalidationNonce:    1,
-		}
-		//k.SetOutgoingLogicCall(ctx, &call)
-	}
-}

--- a/module/x/gravity/module.go
+++ b/module/x/gravity/module.go
@@ -155,9 +155,6 @@ func (am AppModule) BeginBlock(ctx sdk.Context, _ abci.RequestBeginBlock) {}
 // EndBlock implements app module
 func (am AppModule) EndBlock(ctx sdk.Context, _ abci.RequestEndBlock) []abci.ValidatorUpdate {
 	EndBlocker(ctx, am.keeper)
-	// this begin blocker is only for testing purposes, don't import into your
-	// own chain running gravity
-	TestingEndBlocker(ctx, am.keeper)
 	return []abci.ValidatorUpdate{}
 }
 


### PR DESCRIPTION
One of the current issues we have in repo is that the arbitrary logic testing flow is insufficient. There's no end to end test of arbitrary logic functionality and in fact some of the event parsing isn't tested at all.

The problem is that triggering arbitrary logic right now requires an external Cosmos module, so there's no good way to simulate an external module without actually having one.

I believe that we should expand the feature set of the Gravity bridge to allow arbitrary logic calls from regular users, which should be secure so long as we properly remove the required funds from the users accounts before allowing the call. We can then test this flow end to end in this repo and make sure that the vast majority of arbitrary logic functions work.

Right now this PR only removes the ill conceived testing end blocker, which has been disabled for some time anyways.