### PR TITLE
Fix MsgCancelSendToEth

### DIFF
--- a/module/x/gravity/handler.go
+++ b/module/x/gravity/handler.go
@@ -50,6 +50,9 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 		case *types.MsgValsetUpdatedClaim:
 			res, err := msgServer.ValsetUpdateClaim(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
+		case *types.MsgCancelSendToEth:
+			res, err := msgServer.CancelSendToEth(sdk.WrapSDKContext(ctx), msg)
+			return sdk.WrapServiceResult(ctx, res, err)
 
 		default:
 			return nil, sdkerrors.Wrap(sdkerrors.ErrUnknownRequest, fmt.Sprintf("Unrecognized Gravity Msg type: %v", msg.Type()))

--- a/module/x/gravity/keeper/batch_test.go
+++ b/module/x/gravity/keeper/batch_test.go
@@ -384,6 +384,7 @@ func TestPoolTxRefund(t *testing.T) {
 	var (
 		now                 = time.Now().UTC()
 		mySender, _         = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3kn")
+		notMySender, _      = sdk.AccAddressFromBech32("cosmos1ahx7f8wyertuus9r20284ej0asrs085case3km")
 		myReceiver          = "0xd041c41EA1bf0F006ADBb6d2c9ef9D425dE5eaD7"
 		myTokenContractAddr = "0x429881672B9AE42b8EbA0E26cD9C73711b891Ca5" // Pickle
 		allVouchers         = sdk.NewCoins(
@@ -420,9 +421,13 @@ func TestPoolTxRefund(t *testing.T) {
 	err1 := input.GravityKeeper.RemoveFromOutgoingPoolAndRefund(ctx, 1, mySender)
 	require.Error(t, err1)
 
+	// try to refund somebody else's tx
+	err2 := input.GravityKeeper.RemoveFromOutgoingPoolAndRefund(ctx, 4, notMySender)
+	require.Error(t, err2)
+
 	// try to refund a tx that's in the pool
-	err2 := input.GravityKeeper.RemoveFromOutgoingPoolAndRefund(ctx, 4, mySender)
-	require.NoError(t, err2)
+	err3 := input.GravityKeeper.RemoveFromOutgoingPoolAndRefund(ctx, 4, mySender)
+	require.NoError(t, err3)
 
 	// make sure refund was issued
 	balances := input.BankKeeper.GetAllBalances(ctx, mySender)

--- a/module/x/gravity/keeper/pool.go
+++ b/module/x/gravity/keeper/pool.go
@@ -101,6 +101,16 @@ func (k Keeper) RemoveFromOutgoingPoolAndRefund(ctx sdk.Context, txId uint64, se
 		return err
 	}
 
+	// Check that this user actually sent the transaction, this prevents someone from refunding someone
+	// elses transaction to themselves.
+	txSender, err := sdk.AccAddressFromBech32(tx.Sender)
+	if err != nil {
+		panic("Invalid address in store!")
+	}
+	if !txSender.Equals(sender) {
+		return sdkerrors.Wrapf(types.ErrInvalid, "Sender %s did not send Id %d", sender, txId)
+	}
+
 	found := false
 	poolTx := k.GetPoolTransactions(ctx)
 	for _, pTx := range poolTx {

--- a/module/x/gravity/types/msgs.go
+++ b/module/x/gravity/types/msgs.go
@@ -13,6 +13,7 @@ var (
 	_ sdk.Msg = &MsgSetOrchestratorAddress{}
 	_ sdk.Msg = &MsgValsetConfirm{}
 	_ sdk.Msg = &MsgSendToEth{}
+	_ sdk.Msg = &MsgCancelSendToEth{}
 	_ sdk.Msg = &MsgRequestBatch{}
 	_ sdk.Msg = &MsgConfirmBatch{}
 	_ sdk.Msg = &MsgERC20DeployedClaim{}
@@ -616,8 +617,9 @@ func (b *MsgValsetUpdatedClaim) ClaimHash() []byte {
 }
 
 // NewMsgCancelSendToEth returns a new msgSetOrchestratorAddress
-func NewMsgCancelSendToEth(val sdk.ValAddress, id uint64) *MsgCancelSendToEth {
+func NewMsgCancelSendToEth(user sdk.AccAddress, id uint64) *MsgCancelSendToEth {
 	return &MsgCancelSendToEth{
+		Sender:        user.String(),
 		TransactionId: id,
 	}
 }
@@ -630,7 +632,7 @@ func (msg *MsgCancelSendToEth) Type() string { return "cancel_send_to_eth" }
 
 // ValidateBasic performs stateless checks
 func (msg *MsgCancelSendToEth) ValidateBasic() (err error) {
-	_, err = sdk.ValAddressFromBech32(msg.Sender)
+	_, err = sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {
 		return err
 	}
@@ -644,11 +646,11 @@ func (msg *MsgCancelSendToEth) GetSignBytes() []byte {
 
 // GetSigners defines whose signature is required
 func (msg *MsgCancelSendToEth) GetSigners() []sdk.AccAddress {
-	acc, err := sdk.ValAddressFromBech32(msg.Sender)
+	acc, err := sdk.AccAddressFromBech32(msg.Sender)
 	if err != nil {
 		panic(err)
 	}
-	return []sdk.AccAddress{sdk.AccAddress(acc)}
+	return []sdk.AccAddress{acc}
 }
 
 // MsgSubmitBadSignatureEvidence


### PR DESCRIPTION
It seems I was in a bit too much of a rush when copying the signing
boilerplate for this message type.

Note that I am relying on the get_signers implementation to ensure
msg.Sender has signed the message. In msg_server.go we just remove the
tx from the pool with the assumption that it's from the sender.

thanks to @mankenavenkatesh  for pointing this out. 